### PR TITLE
Use BullMQ jobId for aggregation dedup (#2)

### DIFF
--- a/apps/api/src/routes/events.ts
+++ b/apps/api/src/routes/events.ts
@@ -167,15 +167,13 @@ export const eventsRoutes: FastifyPluginAsync = async (server) => {
         }
       }
 
-      // Add jobs to queue
+      // Add jobs to queue with stable jobId for deduplication
       const jobs = Array.from(aggregationJobs.values()).map(job => ({
         name: 'aggregate-counter',
         data: job,
         opts: {
           delay: 1000, // Small delay to batch events
-          deduplication: {
-            id: `${job.tenantId}:${job.metric}:${job.customerRef}:${job.periodStart}`,
-          },
+          jobId: `${job.tenantId}:${job.metric}:${job.customerRef}:${job.periodStart}`,
         },
       }));
 


### PR DESCRIPTION
Replace custom deduplication option with BullMQ jobId to ensure duplicate aggregation jobs collapse.\n\n- Changes: use jobId  for /v1/events enqueue\n- Rationale: BullMQ doesn't support custom dedup; jobId is the intended mechanism\n- Notes: No behavior change beyond dedup correctness; tests/build pending due to unrelated workspace issues