### PR TITLE
demo: add Prometheus metrics to CloudAPI demo

### DIFF
--- a/demo/cloudapi-saas/README.md
+++ b/demo/cloudapi-saas/README.md
@@ -141,6 +141,23 @@ Expected:
 - Blocked: requests return 402 Payment Required
 - After resolve: requests succeed normally
 
+### **Prometheus Metrics**
+- Exposes `/metrics` for Prometheus scrape with counters and histograms
+- Metrics include: `http_requests_total`, `http_request_duration_ms`, `usage_events_tracked_total`, `dunning_state_transitions_total`
+
+#### Try it locally
+```bash
+cd demo/cloudapi-saas
+npm i
+node src/server.js
+
+# in another terminal
+curl -s http://localhost:4000/metrics | head
+```
+Example queries:
+- `sum by (route, method) (rate(http_requests_total[1m]))`
+- `histogram_quantile(0.95, sum(rate(http_request_duration_ms_bucket[5m])) by (le, route))`
+
 ### **Credits Lifecycle (Entitlements)**
 - Issues credits (e.g., 50k API calls), burns FIFO by usage, handles expiry and optional rollover
 - Shows remaining, burned, expired, rolled credits, and overage beyond credits

--- a/demo/cloudapi-saas/package-lock.json
+++ b/demo/cloudapi-saas/package-lock.json
@@ -19,10 +19,19 @@
         "express-validator": "^7.0.1",
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
+        "prom-client": "^15.1.3",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
         "nodemon": "^3.0.2"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/accepts": {
@@ -92,6 +101,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -1061,6 +1075,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1320,6 +1346,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/to-regex-range": {

--- a/demo/cloudapi-saas/package.json
+++ b/demo/cloudapi-saas/package.json
@@ -31,6 +31,7 @@
     "express-validator": "^7.0.1",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
+    "prom-client": "^15.1.3",
     "uuid": "^9.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds Prometheus instrumentation to the CloudAPI demo.

- Exposes /metrics endpoint (prom-client registry)
- Counters: http_requests_total, usage_events_tracked_total, dunning_state_transitions_total 
- Histogram: http_request_duration_ms
- Docs: README with how to scrape and example queries\n\nHow to test:
1) cd demo/cloudapi-saas && npm i
2) node src/server.js
3) curl -s http://localhost:4000/metrics | head
Notes:
- Metrics middleware records route, method, status labels
- Usage tracking increments metric-specific counters