### PR TITLE
feat(sim-cli): Simulator CLI (validate/run/report) + examples + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
           pnpm --filter @stripemeter/admin-ui test
           pnpm --filter @stripemeter/customer-widget test
           pnpm --filter @stripemeter/workers test
+          # Simulator CLI scenario checks
+          pnpm build
+          pnpm run sim validate --dir examples
+          pnpm run sim run --dir examples --out results --seed 42
+          pnpm run sim report --dir examples --results results --fail-on-diff
         env:
           NODE_ENV: test
       

--- a/README.md
+++ b/README.md
@@ -7,7 +7,18 @@
 [![Community](https://img.shields.io/badge/Join-Community-blue)](https://github.com/geminimir/stripemeter/discussions)
 [![Contributors](https://img.shields.io/github/contributors/geminimir/stripemeter.svg)](https://github.com/geminimir/stripemeter/graphs/contributors)
 
-**StripeMeter** is a production-ready, Stripe-native usage metering system that brings transparency and trust to SaaS billing. Built by developers, for developers who believe customers deserve to see exactly what they're paying for.
+**Stability: Alpha (v0.1.0)** — See [Release Notes](docs/RELEASE_NOTES_v0.1.0.md) and [Operator Playbook](RECONCILIATION.md).
+
+### Try in 5 minutes
+
+```bash
+pnpm i -w
+docker compose up -d
+pnpm -r build
+pnpm dev
+```
+
+**StripeMeter** is an alpha-stage, Stripe-native usage metering system that brings transparency and trust to SaaS billing. Built by developers, for developers who believe customers deserve to see exactly what they're paying for.
 
 ## Why StripeMeter?
 

--- a/RECONCILIATION.md
+++ b/RECONCILIATION.md
@@ -1,0 +1,49 @@
+# Reconciliation Playbook (Alpha)
+
+This guide helps operators triage and correct differences between StripeMeter and Stripe for v0.1.0.
+
+## Policy
+
+- Drift epsilon: 0.5% relative difference per subscription item per period
+- Within epsilon: record a small adjustment to align and proceed
+- Beyond epsilon: backfill underlying events, then re-run aggregation
+
+## Mechanics
+
+- Watermarks: track last processed timestamp per counter; late events within the lateness window trigger re-aggregation
+- Delta push: writer sends only the delta from last `pushed_total` per item to Stripe
+- Hourly compare: reconciliation job compares local totals vs Stripe reported usage; flags items beyond epsilon
+
+## Triage steps
+
+1. Identify item: tenant, customer, metric, period
+2. Inspect local totals and watermark
+3. Check Stripe reported usage for the same item/period
+4. Determine cause: late events, duplicates, manual Stripe change
+5. Decide action: adjust (<= 0.5%) or backfill (> 0.5%)
+6. Verify: re-run compare to confirm parity
+
+## Common commands (examples)
+
+```bash
+# Health check
+curl -sS http://localhost:3000/health
+
+# Recent reconciliation alerts (example endpoint)
+curl -sS http://localhost:3000/v1/reconciliation?limit=20 | jq '.items[] | {metric, period, diffPct}'
+
+# Recent events for a customer/metric (example endpoint)
+curl -sS -X POST http://localhost:3000/v1/events/query \
+  -H 'Content-Type: application/json' \
+  -d '{"tenantId":"TENANT","customerRef":"CUST","metric":"api_calls","period":"2025-01"}'
+```
+
+## Examples
+
+- Late event (< 48h): falls within lateness window, re-aggregate; if residual diff <= 0.5%, adjust.
+- Duplicate event: idempotency key should dedupe; if not, create a negative adjustment.
+
+## Notes
+
+- Best-effort alpha flow; review large drifts manually.
+- Keep logs from API and workers when filing issues.

--- a/docs/RELEASE_NOTES_v0.1.0.md
+++ b/docs/RELEASE_NOTES_v0.1.0.md
@@ -1,0 +1,72 @@
+# StripeMeter v0.1.0 (Alpha)
+
+This is the first tagged release of StripeMeter focused on a smooth local demo and a clear operator story. It is suitable for evaluation and prototypes.
+
+## Scope
+
+- Works locally with Docker (Postgres + Redis)
+- Core apps: API, Workers, Admin UI, Customer Widget, Pricing Simulator
+- Demo: CloudAPI SaaS showcase under `demo/cloudapi-saas`
+
+## Stability
+
+- Stability: Alpha. Expect breaking changes before v1.0.
+
+## What’s in
+
+- Usage ingestion API and usage/projection endpoints
+- Workers: aggregation, reconciliation, alert monitor, Stripe writer (best-effort)
+- Reconciliation loop with epsilon threshold
+- Admin UI and customer widget for basic flows
+- Pricing simulator library and docs
+
+## What’s out (for now)
+
+- High-availability/multi-region guidance
+- Advanced authz/SSO, RBAC hardening
+- Performance SLO guarantees at scale
+- Kubernetes/Helm production guidance
+
+## Known limitations
+
+- Single-node, developer setup focused
+- Best-effort reconciliation; manual review recommended for large drifts
+- Limited observability; basic logs and health checks only
+
+## Requirements
+
+- Node.js 20+
+- pnpm 8+
+- Docker Desktop
+
+## Try in 5 minutes
+
+```bash
+git clone https://github.com/geminimir/stripemeter.git
+cd stripemeter
+pnpm i -w
+docker compose up -d
+pnpm -r build && pnpm dev
+
+# optional demo
+cd demo/cloudapi-saas && ./demo-start.sh
+```
+
+Health check: `curl -sS http://localhost:3000/health`
+
+## Reconciliation (operator playbook)
+
+See `RECONCILIATION.md` for drift epsilon policy (0.5%), watermarks, delta push, hourly compare, and triage steps.
+
+## Roadmap (next)
+
+- Observability: metrics, dashboards, alerting
+- Hardening: auth/tenant scoping, retries/backoff across services
+- Performance baselines and benchmarks
+- Packaging: container images and production guides
+
+## Acknowledgements
+
+MIT licensed. Built by the community for transparent usage-based billing.
+
+

--- a/docs/simulator-getting-started.md
+++ b/docs/simulator-getting-started.md
@@ -336,3 +336,60 @@ segments.forEach(segment => {
 - 🐛 [Report Issues](https://github.com/geminimir/stripemeter/issues)
 - 💬 [Community Discussions](https://github.com/geminimir/stripemeter/discussions)
 - 📧 [Support](mailto:support@stripemeter.io)
+
+## Simulator CLI (sim) quickstart
+
+Use the local CLI to validate scenarios, run them offline using the pricing engine, and report diffs against expected artifacts.
+
+```bash
+# Build workspace (first time or after changes)
+pnpm build
+
+# Validate all scenarios under examples/
+pnpm run sim validate --dir examples
+
+# Run scenarios and write results to results/
+pnpm run sim run --dir examples --out results --seed 42
+
+# Record the current results as expected artifacts next to scenarios
+pnpm run sim run --dir examples --out results --record
+
+# Diff actual results vs expected and fail on differences
+pnpm run sim report --dir examples --results results --fail-on-diff
+```
+
+- Scenarios live in `scenarios/` or any folder you specify (see `examples/`).
+- Scenario files use `.sim.json` extension and minimally require `metadata`, `inputs.usageItems`, and an `expected.total` to assert.
+- You can set per-scenario tolerances via `tolerances.absolute` and `tolerances.relative` for numeric diffs.
+
+Example scenario skeleton:
+
+```json
+{
+  "metadata": { "name": "tiered-basic", "version": "1" },
+  "inputs": {
+    "customerId": "cust_1",
+    "periodStart": "2024-01-01",
+    "periodEnd": "2024-01-31",
+    "usageItems": [
+      {
+        "metric": "requests",
+        "quantity": 350,
+        "priceConfig": {
+          "model": "tiered",
+          "currency": "USD",
+          "tiers": [
+            { "upTo": 100, "unitPrice": 0.1 },
+            { "upTo": 500, "unitPrice": 0.08 },
+            { "upTo": null, "unitPrice": 0.05 }
+          ]
+        }
+      }
+    ]
+  },
+  "expected": { "total": 28.0 },
+  "tolerances": { "absolute": 0.001, "relative": 0.0005 }
+}
+```
+
+CI runs validate → run → report for `examples/`. Place your own scenarios in `scenarios/` and mirror the same commands locally.

--- a/examples/flat-package.expected.json
+++ b/examples/flat-package.expected.json
@@ -1,0 +1,27 @@
+{
+  "customerId": "cust_2",
+  "periodStart": "2024-01-01",
+  "periodEnd": "2024-01-31",
+  "lineItems": [
+    {
+      "metric": "seats",
+      "quantity": 7,
+      "unitPrice": 10,
+      "subtotal": 70,
+      "description": "7 units of seats"
+    },
+    {
+      "metric": "bundles",
+      "quantity": 13,
+      "unitPrice": 5,
+      "subtotal": 20,
+      "description": "13 units of bundles"
+    }
+  ],
+  "subtotal": 90,
+  "credits": 0,
+  "adjustments": 0,
+  "tax": 9,
+  "total": 99,
+  "currency": "USD"
+}

--- a/examples/flat-package.sim.json
+++ b/examples/flat-package.sim.json
@@ -1,0 +1,24 @@
+{
+  "metadata": { "name": "flat-package", "version": "1" },
+  "inputs": {
+    "customerId": "cust_2",
+    "periodStart": "2024-01-01",
+    "periodEnd": "2024-01-31",
+    "usageItems": [
+      {
+        "metric": "seats",
+        "quantity": 7,
+        "priceConfig": { "model": "flat", "currency": "USD", "unitPrice": 10, "minimumCharge": 50 }
+      },
+      {
+        "metric": "bundles",
+        "quantity": 13,
+        "priceConfig": { "model": "package", "currency": "USD", "unitPrice": 5, "packageSize": 4 }
+      }
+    ],
+    "taxRate": 10
+  },
+  "expected": { "total": 0 }
+}
+
+

--- a/examples/tiered-basic.expected.json
+++ b/examples/tiered-basic.expected.json
@@ -1,0 +1,20 @@
+{
+  "customerId": "cust_1",
+  "periodStart": "2024-01-01",
+  "periodEnd": "2024-01-31",
+  "lineItems": [
+    {
+      "metric": "requests",
+      "quantity": 350,
+      "unitPrice": 0.09,
+      "subtotal": 30,
+      "description": "350 units of requests"
+    }
+  ],
+  "subtotal": 30,
+  "credits": 0,
+  "adjustments": 0,
+  "tax": 0,
+  "total": 30,
+  "currency": "USD"
+}

--- a/examples/tiered-basic.sim.json
+++ b/examples/tiered-basic.sim.json
@@ -1,0 +1,35 @@
+{
+  "metadata": { "name": "tiered-basic", "version": "1" },
+  "model": {
+    "model": "tiered",
+    "currency": "USD",
+    "tiers": [
+      { "upTo": 100, "unitPrice": 0.1 },
+      { "upTo": 500, "unitPrice": 0.08 },
+      { "upTo": null, "unitPrice": 0.05 }
+    ]
+  },
+  "inputs": {
+    "customerId": "cust_1",
+    "periodStart": "2024-01-01",
+    "periodEnd": "2024-01-31",
+    "usageItems": [
+      {
+        "metric": "requests",
+        "quantity": 350,
+        "priceConfig": {
+          "model": "tiered",
+          "currency": "USD",
+          "tiers": [
+            { "upTo": 100, "unitPrice": 0.1 },
+            { "upTo": 500, "unitPrice": 0.08 },
+            { "upTo": null, "unitPrice": 0.05 }
+          ]
+        }
+      }
+    ]
+  },
+  "expected": { "total": 0 }
+}
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stripemeter",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Stripe-native usage metering and cost experience platform",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "db:seed": "pnpm --filter @stripemeter/database seed",
     "typecheck": "tsc -b --pretty false",
     "precommit": "pnpm lint && pnpm typecheck && pnpm run test:simulator:fast",
-    "prepare": "husky"
+    "prepare": "husky",
+    "sim": "node packages/simulator-cli/dist/index.js"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/packages/simulator-cli/package.json
+++ b/packages/simulator-cli/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@stripemeter/simulator-cli",
+  "version": "0.1.0",
+  "description": "Simulator CLI to run, validate, and report on pricing scenarios",
+  "private": true,
+  "bin": {
+    "sim": "./dist/index.js",
+    "stripemeter-sim": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@stripemeter/pricing-lib": "workspace:*",
+    "commander": "^11.1.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "tsup": "^8.0.1",
+    "typescript": "^5.3.3",
+    "vitest": "^1.2.1"
+  }
+}
+
+

--- a/packages/simulator-cli/src/index.ts
+++ b/packages/simulator-cli/src/index.ts
@@ -1,0 +1,60 @@
+import { Command } from 'commander';
+import { runValidate } from './modules/validate';
+import { runRun } from './modules/run';
+import { runReport } from './modules/report';
+
+const program = new Command();
+
+program
+  .name('sim')
+  .description('Simulator CLI to run, validate, and report scenarios')
+  .version('0.1.0');
+
+program
+  .command('validate')
+  .description('Validate scenario files')
+  .option('--scenario <path>', 'Path to a single scenario file (.sim.json)')
+  .option('--dir <path>', 'Directory containing scenario files')
+  .action(async (opts) => {
+    const exitCode = await runValidate(opts);
+    process.exit(exitCode);
+  });
+
+program
+  .command('run')
+  .description('Run scenarios offline and emit results')
+  .option('--scenario <path>', 'Path to a single scenario file (.sim.json)')
+  .option('--dir <path>', 'Directory containing scenario files')
+  .option('--seed <seed>', 'Deterministic seed')
+  .option('--out <dir>', 'Output directory for results', 'results')
+  .option('--record', 'Record results as expected next to scenarios', false)
+  .action(async (opts) => {
+    const exitCode = await runRun(opts);
+    process.exit(exitCode);
+  });
+
+program
+  .command('report')
+  .description('Diff results against expected artifacts')
+  .option('--scenario <path>', 'Path to a single scenario file (.sim.json)')
+  .option('--dir <path>', 'Directory containing scenario files')
+  .option('--results <dir>', 'Directory containing results JSON', 'results')
+  .option('--format <fmt>', 'Output format: table|json|md', 'table')
+  .option('--fail-on-diff', 'Exit non-zero if diffs found', false)
+  .action(async (opts) => {
+    const exitCode = await runReport({
+      scenario: opts.scenario,
+      dir: opts.dir,
+      results: opts.results,
+      format: opts.format,
+      failOnDiff: !!opts.failOnDiff,
+    });
+    process.exit(exitCode);
+  });
+
+program.parseAsync().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+
+

--- a/packages/simulator-cli/src/modules/report.ts
+++ b/packages/simulator-cli/src/modules/report.ts
@@ -1,0 +1,113 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { ScenarioSchema } from './schema';
+
+interface ReportOptions {
+  scenario?: string;
+  dir?: string;
+  results?: string;
+  format?: 'table' | 'json' | 'md';
+  failOnDiff?: boolean;
+}
+
+type Invoice = {
+  total: number;
+  subtotal?: number;
+  tax?: number;
+  currency?: string;
+  lineItems?: Array<{ metric: string; quantity: number; unitPrice?: number; subtotal?: number }>;
+};
+
+function approxEqual(a: number, b: number, abs = 0, rel = 0): boolean {
+  const diff = Math.abs(a - b);
+  if (diff <= abs) return true;
+  const denom = Math.max(1, Math.abs(b));
+  return diff / denom <= rel;
+}
+
+async function readJson(filePath: string): Promise<any> {
+  const raw = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function findExpectedPath(scenarioPath: string): string {
+  const base = scenarioPath.replace(/\.sim\.json$/, '');
+  return `${base}.expected.json`;
+}
+
+export async function runReport(opts: ReportOptions): Promise<number> {
+  const resultsDir = path.resolve(process.cwd(), opts.results ?? 'results');
+  const format = (opts.format ?? 'table') as 'table' | 'json' | 'md';
+
+  const scenarios: string[] = [];
+  if (opts.scenario) scenarios.push(path.resolve(process.cwd(), opts.scenario));
+  if (opts.dir) {
+    const dirPath = path.resolve(process.cwd(), opts.dir);
+    const items = await fs.readdir(dirPath);
+    for (const item of items) if (item.endsWith('.sim.json')) scenarios.push(path.join(dirPath, item));
+  }
+  if (scenarios.length === 0) {
+    console.error('No scenario provided. Use --scenario <file> or --dir <directory>.');
+    return 1;
+  }
+
+  let hadDiff = false;
+
+  for (const scenarioPath of scenarios) {
+    const name = path.basename(scenarioPath).replace(/\.sim\.json$/, '');
+    const expectedPath = findExpectedPath(scenarioPath);
+    const resultPath = path.join(resultsDir, `${name}.result.json`);
+
+    try {
+      // Pull tolerances from scenario if present; default to conservative values
+      const scenarioRaw = await readJson(scenarioPath);
+      const parsedScenario = ScenarioSchema.safeParse(scenarioRaw);
+      const absTol = parsedScenario.success && parsedScenario.data.tolerances?.absolute !== undefined
+        ? parsedScenario.data.tolerances.absolute
+        : 0.001;
+      const relTol = parsedScenario.success && parsedScenario.data.tolerances?.relative !== undefined
+        ? parsedScenario.data.tolerances.relative
+        : 0.0005;
+
+      const expected: Invoice = await readJson(expectedPath);
+      const actual: Invoice = await readJson(resultPath);
+
+      const diffs: string[] = [];
+      if (!approxEqual(actual.total, expected.total, absTol, relTol)) {
+        diffs.push(`total: expected ${expected.total}, got ${actual.total}`);
+      }
+      if (expected.subtotal !== undefined && actual.subtotal !== undefined && !approxEqual(actual.subtotal, expected.subtotal, absTol, relTol)) {
+        diffs.push(`subtotal: expected ${expected.subtotal}, got ${actual.subtotal}`);
+      }
+      if (expected.tax !== undefined && actual.tax !== undefined && !approxEqual(actual.tax, expected.tax, absTol, relTol)) {
+        diffs.push(`tax: expected ${expected.tax}, got ${actual.tax}`);
+      }
+
+      if (format === 'json') {
+        console.log(JSON.stringify({ scenario: name, diffs }, null, 2));
+      } else if (format === 'md') {
+        if (diffs.length === 0) {
+          console.log(`| ${name} | OK |`);
+        } else {
+          console.log(`| ${name} | ${diffs.join('; ')} |`);
+        }
+      } else {
+        if (diffs.length === 0) {
+          console.log(`OK: ${name}`);
+        } else {
+          console.log(`DIFF: ${name}`);
+          for (const d of diffs) console.log(` - ${d}`);
+        }
+      }
+
+      if (diffs.length > 0) hadDiff = true;
+    } catch (err: any) {
+      console.error(`Failed to generate report for ${name}: ${err.message}`);
+      hadDiff = true;
+    }
+  }
+
+  return hadDiff && opts.failOnDiff ? 1 : 0;
+}
+
+

--- a/packages/simulator-cli/src/modules/run.ts
+++ b/packages/simulator-cli/src/modules/run.ts
@@ -1,0 +1,95 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { ScenarioSchema, type Scenario } from './schema';
+import { InvoiceSimulator } from '@stripemeter/pricing-lib';
+
+interface RunOptions {
+  scenario?: string;
+  dir?: string;
+  seed?: string;
+  out?: string;
+  record?: boolean;
+}
+
+function getScenarioTargets(opts: { scenario?: string; dir?: string }): string[] {
+  const targets: string[] = [];
+  if (opts.scenario) targets.push(path.resolve(process.cwd(), opts.scenario));
+  if (opts.dir) {
+    const dirPath = path.resolve(process.cwd(), opts.dir);
+    const items = fs.readdir(dirPath).then((list) =>
+      list.filter((f) => f.endsWith('.sim.json')).map((f) => path.join(dirPath, f))
+    );
+    // We cannot await here; handled by caller to simplify
+    throw new Error('Internal misuse: getScenarioTargets with dir requires async handling');
+  }
+  return targets;
+}
+
+function applySeed(seed?: string) {
+  if (!seed) return;
+  // Determinism placeholder; pricing-lib currently deterministic.
+  process.env.SIM_SEED = seed;
+}
+
+async function writeJson(filePath: string, data: unknown) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2) + '\n', 'utf8');
+}
+
+export async function runRun(opts: RunOptions): Promise<number> {
+  const outDir = path.resolve(process.cwd(), opts.out ?? 'results');
+  applySeed(opts.seed);
+
+  const targets: string[] = [];
+  if (opts.scenario) {
+    targets.push(path.resolve(process.cwd(), opts.scenario));
+  }
+  if (opts.dir) {
+    const dirPath = path.resolve(process.cwd(), opts.dir);
+    const items = await fs.readdir(dirPath);
+    for (const item of items) if (item.endsWith('.sim.json')) targets.push(path.join(dirPath, item));
+  }
+  if (targets.length === 0) {
+    console.error('No scenario provided. Use --scenario <file> or --dir <directory>.');
+    return 1;
+  }
+
+  let hadError = false;
+  const simulator = new InvoiceSimulator();
+
+  for (const file of targets) {
+    try {
+      const raw = await fs.readFile(file, 'utf8');
+      const json = JSON.parse(raw);
+      const parsed = ScenarioSchema.parse(json) as Scenario;
+
+      const invoice = simulator.simulate({
+        customerId: parsed.inputs.customerId,
+        periodStart: parsed.inputs.periodStart,
+        periodEnd: parsed.inputs.periodEnd,
+        usageItems: parsed.inputs.usageItems,
+        commitments: parsed.inputs.commitments,
+        credits: parsed.inputs.credits,
+        taxRate: parsed.inputs.taxRate,
+      });
+
+      const scenarioName = path.basename(file).replace(/\.sim\.json$/, '');
+      const resultPath = path.join(outDir, `${scenarioName}.result.json`);
+      await writeJson(resultPath, invoice);
+      console.log(`Wrote ${resultPath}`);
+
+      if (opts.record) {
+        const expectedPath = path.join(path.dirname(file), `${scenarioName}.expected.json`);
+        await writeJson(expectedPath, invoice);
+        console.log(`Recorded expected -> ${expectedPath}`);
+      }
+    } catch (err: any) {
+      hadError = true;
+      console.error(`Failed to run scenario ${file}: ${err.message}`);
+    }
+  }
+
+  return hadError ? 1 : 0;
+}
+
+

--- a/packages/simulator-cli/src/modules/schema.ts
+++ b/packages/simulator-cli/src/modules/schema.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+
+export const PriceTierSchema = z.object({
+  upTo: z.number().nullable(),
+  unitPrice: z.number(),
+  flatPrice: z.number().optional(),
+});
+
+export const PriceConfigSchema = z.object({
+  model: z.enum(['tiered', 'volume', 'graduated', 'flat', 'package']),
+  currency: z.string(),
+  tiers: z.array(PriceTierSchema).optional(),
+  unitPrice: z.number().optional(),
+  packageSize: z.number().int().positive().optional(),
+  minimumCharge: z.number().optional(),
+  maximumCharge: z.number().optional(),
+});
+
+export const UsageLineItemSchema = z.object({
+  metric: z.string(),
+  quantity: z.number().nonnegative(),
+  priceConfig: PriceConfigSchema,
+});
+
+export const CommitmentSchema = z.object({
+  amount: z.number().nonnegative(),
+  startDate: z.string(),
+  endDate: z.string(),
+  applied: z.number().nonnegative(),
+});
+
+export const CreditSchema = z.object({
+  amount: z.number().nonnegative(),
+  reason: z.string(),
+  expiresAt: z.string().optional(),
+});
+
+export const TolerancesSchema = z.object({
+  absolute: z.number().nonnegative().optional(),
+  relative: z.number().min(0).max(1).optional(),
+});
+
+export const ScenarioSchema = z.object({
+  metadata: z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    version: z.string().default('1'),
+  }),
+  model: z
+    .union([
+      z.object({ reference: z.string() }),
+      PriceConfigSchema,
+    ])
+    .optional(),
+  inputs: z.object({
+    customerId: z.string(),
+    periodStart: z.string(),
+    periodEnd: z.string(),
+    usageItems: z.array(UsageLineItemSchema),
+    commitments: z.array(CommitmentSchema).optional(),
+    credits: z.array(CreditSchema).optional(),
+    taxRate: z.number().optional(),
+  }),
+  expected: z.object({
+    subtotal: z.number().optional(),
+    tax: z.number().optional(),
+    total: z.number(),
+    currency: z.string().optional(),
+    lineItems: z
+      .array(
+        z.object({
+          metric: z.string(),
+          quantity: z.number(),
+          unitPrice: z.number().optional(),
+          subtotal: z.number().optional(),
+        })
+      )
+      .optional(),
+  }),
+  tolerances: TolerancesSchema.optional(),
+});
+
+export type Scenario = z.infer<typeof ScenarioSchema>;
+
+

--- a/packages/simulator-cli/src/modules/validate.ts
+++ b/packages/simulator-cli/src/modules/validate.ts
@@ -1,0 +1,57 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { ScenarioSchema } from './schema';
+
+interface ValidateOptions {
+  scenario?: string;
+  dir?: string;
+}
+
+export async function runValidate(opts: ValidateOptions): Promise<number> {
+  const targets: string[] = [];
+
+  if (opts.scenario) {
+    targets.push(path.resolve(process.cwd(), opts.scenario));
+  }
+
+  if (opts.dir) {
+    const dirPath = path.resolve(process.cwd(), opts.dir);
+    const items = await fs.readdir(dirPath);
+    for (const item of items) {
+      if (item.endsWith('.sim.json')) {
+        targets.push(path.join(dirPath, item));
+      }
+    }
+  }
+
+  if (targets.length === 0) {
+    console.error('No scenario provided. Use --scenario <file> or --dir <directory>.');
+    return 1;
+  }
+
+  let hadError = false;
+
+  for (const file of targets) {
+    try {
+      const raw = await fs.readFile(file, 'utf8');
+      const json = JSON.parse(raw);
+      const result = ScenarioSchema.safeParse(json);
+      if (!result.success) {
+        hadError = true;
+        console.error(`Validation failed for ${file}:`);
+        for (const issue of result.error.issues) {
+          console.error(` - ${issue.path.join('.')}: ${issue.message}`);
+        }
+      } else {
+        console.log(`OK: ${file}`);
+      }
+    } catch (err: any) {
+      hadError = true;
+      console.error(`Error reading ${file}: ${err.message}`);
+    }
+  }
+
+  return hadError ? 1 : 0;
+}
+
+

--- a/packages/simulator-cli/tsconfig.json
+++ b/packages/simulator-cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}
+
+

--- a/packages/simulator-cli/tsup.config.ts
+++ b/packages/simulator-cli/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: false,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  banner: {
+    js: '#!/usr/bin/env node'
+  }
+});
+
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,6 +377,31 @@ importers:
         specifier: ^1.2.1
         version: 1.6.1(@types/node@20.19.11)
 
+  packages/simulator-cli:
+    dependencies:
+      '@stripemeter/pricing-lib':
+        specifier: workspace:*
+        version: link:../pricing-lib
+      commander:
+        specifier: ^11.1.0
+        version: 11.1.0
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.11
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.2
+      vitest:
+        specifier: ^1.2.1
+        version: 1.6.1(@types/node@20.19.11)
+
 packages:
 
   '@alloc/quick-lru@5.2.0':
@@ -1691,6 +1716,10 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -4525,6 +4554,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@11.1.0: {}
 
   commander@4.1.1: {}
 


### PR DESCRIPTION
This PR introduces a local Simulator CLI for running pricing scenarios, validating inputs, and reporting diffs against expected artifacts.
Changes
- New package: packages/simulator-cli with commands: `sim validate`, `sim run`, `sim report`
- Zod schema for scenarios with optional tolerances
- Example scenarios under `examples/` and recorded expected artifacts
- CI workflow updated to validate → run → report
- Docs: quickstart added to docs/simulator-getting-started.md

Usage
- Validate: `pnpm run sim validate --dir examples`
- Run: `pnpm run sim run --dir examples --out results --seed 42`
- Record: `pnpm run sim run --dir examples --out results --record`
- Report: `pnpm run sim report --dir examples --results results --fail-on-diff`
Acceptance
- CLI executes locally and produces artifacts under results/ and examples/ (expected)
- CI step passes validate/run/report on examples
Notes
- v1 is offline-only (pricing-lib); API mode and YAML support can be added later.
- Typecheck noise unrelated to CLI can be addressed in a follow-up.