### PR TITLE
Feat/auth tenancy rbac

### DIFF
--- a/apps/api/src/routes/admin.test.ts
+++ b/apps/api/src/routes/admin.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { buildServer } from '../server';
+
+describe('Admin API Keys', () => {
+  let server: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.BYPASS_AUTH = '1';
+    server = await buildServer();
+    await server.ready();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('creates, rotates and revokes an API key', async () => {
+    // create
+    const keyName = `test-key-${Date.now()}`;
+    const createRes = await server.inject({
+      method: 'POST',
+      url: '/v1/admin/api-keys',
+      payload: { name: keyName },
+    });
+    expect(createRes.statusCode).toBe(201);
+    const created = JSON.parse(createRes.body);
+    expect(created.apiKey).toMatch(/\./);
+    const id = created.key.id;
+
+    // rotate
+    const rotRes = await server.inject({
+      method: 'POST',
+      url: `/v1/admin/api-keys/${id}/rotate`,
+    });
+    expect(rotRes.statusCode).toBe(200);
+    const rotated = JSON.parse(rotRes.body);
+    expect(rotated.apiKey).toMatch(/\./);
+    expect(rotated.key.prefix).not.toBe(created.key.prefix);
+
+    // revoke
+    const revRes = await server.inject({
+      method: 'POST',
+      url: `/v1/admin/api-keys/${id}/revoke`,
+    });
+    expect(revRes.statusCode).toBe(200);
+    const revoked = JSON.parse(revRes.body);
+    expect(revoked.key.active).toBe(false);
+  });
+});
+
+

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,0 +1,58 @@
+import { FastifyInstance } from 'fastify';
+import { db } from '@stripemeter/database';
+import { apiKeys } from '@stripemeter/database';
+import { eq } from 'drizzle-orm';
+import { createHmac, randomBytes } from 'crypto';
+
+export async function adminRoutes(server: FastifyInstance) {
+  server.post('/api-keys', async (request, reply) => {
+    const body = request.body as any;
+    const organisationId = request.tenant?.organisationId || (process.env.BYPASS_AUTH === '1' ? '00000000-0000-0000-0000-000000000000' : undefined);
+    if (!organisationId) return reply.status(401).send({ error: 'unauthenticated' });
+    const name = body?.name || 'New API Key';
+    const projectId = body?.projectId as string | undefined;
+    const scopes = Array.isArray(body?.scopes) ? body.scopes.join(',') : 'project:read,project:write';
+
+    const { apiKey, prefix, last4, secretHash } = generateApiKeyHash('sm');
+    const inserted = await db.insert(apiKeys).values({ organisationId, projectId, name, prefix, lastFour: last4, secretHash, scopes }).returning();
+    return reply.status(201).send({ apiKey, key: inserted[0] });
+  });
+
+  server.post('/api-keys/:id/rotate', async (request, reply) => {
+    const organisationId = request.tenant?.organisationId || (process.env.BYPASS_AUTH === '1' ? '00000000-0000-0000-0000-000000000000' : undefined);
+    if (!organisationId) return reply.status(401).send({ error: 'unauthenticated' });
+    const id = (request.params as any).id as string;
+    const { apiKey, prefix, last4, secretHash } = generateApiKeyHash('sm');
+    const updated = await db.update(apiKeys)
+      .set({ prefix, lastFour: last4, secretHash })
+      .where(eq(apiKeys.id, id))
+      .returning();
+    return reply.status(200).send({ apiKey, key: updated[0] });
+  });
+
+  server.post('/api-keys/:id/revoke', async (request, reply) => {
+    const id = (request.params as any).id as string;
+    const updated = await db.update(apiKeys)
+      .set({ active: false, revokedAt: new Date() })
+      .where(eq(apiKeys.id, id))
+      .returning();
+    return reply.status(200).send({ key: updated[0] });
+  });
+}
+
+function generateApiKeyHash(prefixBase: string) {
+  const prefix = `${prefixBase}_${randomBytes(3).toString('hex')}`;
+  const secret = randomBytes(24).toString('base64url');
+  const apiKey = `${prefix}.${secret}`;
+  const last4 = secret.slice(-4);
+  const secretHash = createHmac('sha256', getKeyDerivationSalt())
+    .update(apiKey)
+    .digest('base64url');
+  return { apiKey, prefix, last4, secretHash };
+}
+
+function getKeyDerivationSalt(): string {
+  return process.env.API_KEY_SALT || 'dev-api-key-salt';
+}
+
+

--- a/apps/api/src/utils/audit.ts
+++ b/apps/api/src/utils/audit.ts
@@ -1,0 +1,34 @@
+import { FastifyRequest, FastifyReply } from 'fastify';
+import { db } from '@stripemeter/database';
+import { auditLogs } from '@stripemeter/database';
+
+export async function persistAuditLog(request: FastifyRequest, reply: FastifyReply) {
+  try {
+    const tenant = request.tenant;
+    if (!tenant) return;
+    const url = request.raw.url || '';
+    if (url.startsWith('/docs') || url.startsWith('/health')) return;
+
+    const action = `${request.method} ${request.routerPath || url.split('?')[0]}`;
+    await db.insert(auditLogs).values({
+      organisationId: tenant.organisationId,
+      projectId: tenant.projectId,
+      actorType: 'api_key',
+      actorId: tenant.apiKeyId,
+      action,
+      resourceType: undefined,
+      resourceId: undefined,
+      ip: request.ip,
+      userAgent: request.headers['user-agent'] as string | undefined,
+      meta: {
+        requestId: request.id,
+        statusCode: reply.statusCode,
+        path: url,
+      },
+    });
+  } catch (err) {
+    request.log.warn({ err }, 'audit log persist failed');
+  }
+}
+
+

--- a/apps/api/src/utils/auth.test.ts
+++ b/apps/api/src/utils/auth.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { buildServer } from '../server';
+
+describe('Auth & Rate Limit middleware', () => {
+  let server: FastifyInstance;
+
+  beforeAll(async () => {
+    delete process.env.BYPASS_AUTH;
+    server = await buildServer();
+    await server.ready();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('rejects when API key missing', async () => {
+    const res = await server.inject({ method: 'GET', url: '/v1/events?tenantId=00000000-0000-0000-0000-000000000000' });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+

--- a/apps/api/src/utils/auth.ts
+++ b/apps/api/src/utils/auth.ts
@@ -1,0 +1,63 @@
+import { FastifyRequest, FastifyReply } from 'fastify';
+import { db } from '@stripemeter/database';
+import { apiKeys } from '@stripemeter/database';
+import { eq, and } from 'drizzle-orm';
+import { createHmac } from 'crypto';
+
+export type TenantContext = {
+  organisationId: string;
+  projectId?: string;
+  apiKeyId: string;
+  apiKeyPrefix: string;
+  scopes: string[];
+};
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    tenant?: TenantContext;
+  }
+}
+
+export async function verifyApiKey(request: FastifyRequest, reply: FastifyReply) {
+  const header = request.headers['authorization'] || request.headers['x-api-key'];
+  const apiKeyRaw = Array.isArray(header) ? header[0] : header;
+  if (!apiKeyRaw) {
+    return reply.status(401).send({ error: 'Missing API key' });
+  }
+
+  const apiKey = apiKeyRaw.toString().startsWith('Bearer ')
+    ? apiKeyRaw.toString().slice(7)
+    : apiKeyRaw.toString();
+
+  const dotIndex = apiKey.indexOf('.');
+  if (dotIndex < 1) return reply.status(401).send({ error: 'Invalid API key format' });
+  const prefix = apiKey.substring(0, dotIndex);
+  const lastFour = apiKey.substring(apiKey.length - 4);
+
+  // Lookup candidate keys by prefix and last4 to reduce hash checks
+  const candidates = await db.select()
+    .from(apiKeys)
+    .where(and(eq(apiKeys.prefix, prefix), eq(apiKeys.lastFour, lastFour)))
+    .limit(10);
+
+  const computed = createHmac('sha256', getKeyDerivationSalt())
+    .update(apiKey)
+    .digest('base64url');
+
+  const match = candidates.find(k => k.secretHash === computed && k.active && !k.revokedAt && (!k.expiresAt || new Date(k.expiresAt) > new Date()));
+  if (!match) return reply.status(401).send({ error: 'Invalid API key' });
+
+  request.tenant = {
+    organisationId: match.organisationId,
+    projectId: match.projectId ?? undefined,
+    apiKeyId: match.id,
+    apiKeyPrefix: match.prefix,
+    scopes: (match.scopes || '').split(',').filter(Boolean),
+  };
+}
+
+function getKeyDerivationSalt(): string {
+  return process.env.API_KEY_SALT || 'dev-api-key-salt';
+}
+
+

--- a/apps/api/src/utils/logger.ts
+++ b/apps/api/src/utils/logger.ts
@@ -36,3 +36,17 @@ export const logger = pino({
     env: process.env.NODE_ENV,
   },
 });
+
+export function logAudit(serverOrRequest: any, event: {
+  organisationId: string;
+  projectId?: string;
+  actorType: 'api_key' | 'user' | 'system';
+  actorId: string;
+  action: string;
+  resourceType?: string;
+  resourceId?: string;
+  meta?: Record<string, any>;
+}) {
+  const l = serverOrRequest && serverOrRequest.log ? serverOrRequest.log : logger;
+  l.info({ audit: event }, 'audit');
+}

--- a/apps/api/src/utils/rate-limit.ts
+++ b/apps/api/src/utils/rate-limit.ts
@@ -1,0 +1,20 @@
+import { FastifyRequest, FastifyReply } from 'fastify';
+import { redis } from '@stripemeter/database';
+
+export function perTenantRateLimit({ limit, windowSeconds }: { limit: number; windowSeconds: number; }) {
+  return async function (request: FastifyRequest, reply: FastifyReply) {
+    const tenant = request.tenant;
+    // If no tenant context (e.g., auth bypass in tests), skip rate limiting
+    if (!tenant) return;
+    const key = `rl:${tenant.organisationId}:${tenant.projectId || 'org'}:${Math.floor(Date.now() / (windowSeconds * 1000))}`;
+    const current = await redis.incr(key);
+    if (current === 1) {
+      await redis.expire(key, windowSeconds);
+    }
+    if (current > limit) {
+      return reply.status(429).send({ error: 'Rate limit exceeded' });
+    }
+  };
+}
+
+

--- a/docs/adr/0001-auth-tenancy-rbac.md
+++ b/docs/adr/0001-auth-tenancy-rbac.md
@@ -1,0 +1,77 @@
+### ADR 0001: Authentication, Tenancy, and RBAC for Stripemeter API
+
+Date: 2025-09-10
+
+Status: Accepted
+
+#### Context
+
+Stripemeter needs multi-tenant isolation with API-key based auth for programmatic access, simple role-based access control (RBAC), per-tenant rate limiting, and tamper-evident audit logging. Security must be simple to operate and safe-by-default, while enabling rotation and revocation of credentials.
+
+#### Decision
+
+- API authentication uses signed API keys with a human-friendly prefix and last-4 display.
+  - Format: `<prefix>.<secret>` where `prefix` is short and identifies the key family.
+  - Only `prefix` and `lastFour(secret)` are stored in plaintext.
+  - Verification uses HMAC-SHA256 over the full presented key using a server-side salt: `HMAC(salt, apiKey)`. Only the resulting `secretHash` is stored.
+  - Keys carry `organisationId` (tenant), optional `projectId`, `scopes`, `expiresAt`, `revokedAt`, and `active` flag.
+
+- Tenancy is explicit across data models using `tenantId`/`organisationId` columns. New tables:
+  - `organisations(id, name, slug, createdAt, updatedAt)`
+  - `projects(id, organisationId, name, slug, createdAt, updatedAt)`
+  - `api_keys(id, organisationId, projectId?, secretHash, prefix, lastFour, name, scopes, expiresAt?, revokedAt?, active, createdAt, updatedAt)`
+  - `org_members(organisationId, userId, role, createdAt, updatedAt)`
+  - `audit_logs(id, organisationId, projectId?, actorType, actorId, action, resourceType?, resourceId?, ip?, userAgent?, meta, createdAt)`
+
+- RBAC uses three roles at the organisation scope: `owner`, `maintainer`, `viewer`.
+  - Initial enforcement is kept at the API-key scope via `scopes` (e.g. `project:read`, `project:write`).
+  - Future enhancement: join `org_members` to user identity provider and enforce per-route RBAC.
+
+- Middleware pipeline:
+  - Auth: Extract API key from `Authorization: Bearer` or `X-API-Key`. Verify via prefix/last-4 candidate lookup and HMAC comparison. Attach `tenant` context to the request: `{ organisationId, projectId?, apiKeyId, apiKeyPrefix, scopes[] }`.
+  - Per-tenant rate limiting: Fixed window in Redis keyed by `org:project:window`. Defaults `1000 req / 60s`, configurable via `TENANT_RATE_LIMIT`, `TENANT_RATE_LIMIT_WINDOW`.
+  - Audit logging: On response, persist an audit record for authenticated calls with request metadata and actor context.
+
+- Admin endpoints:
+  - POST `/v1/admin/api-keys` create key (returns plaintext once), POST `/v1/admin/api-keys/:id/rotate`, POST `/v1/admin/api-keys/:id/revoke`.
+
+#### Security Considerations
+
+- Secret material is never stored; only HMAC hash with server-side salt. Salt is configured via `API_KEY_SALT` and must be rotated via key rollovers.
+- Prefix/last-4 are safe to display and log for support without leaking secrets.
+- Replay-resistant: idempotency keys at the events layer; rate limiting throttles high-volume abuse per tenant.
+- Key rotation path returns new plaintext once; callers must update their stored secret promptly.
+- Key expiration and revocation are enforced during verification. Disabled keys are rejected immediately.
+- Audit logs provide non-repudiation for configuration and data access events. Storage resides in Postgres; move to WORM/immutable store can be considered later.
+
+#### Alternatives Considered
+
+1) Store bcrypt/argon2 of the secret: strong but unnecessary for API-key format (HMAC keyed with server secret achieves the same property with O(1) verification without slow KDF).
+2) JWTs for service-to-service: suitable for user auth; here API key lifecycle and simplicity trump JWT complexity.
+3) Global rate limit only: rejected; per-tenant isolation is necessary to prevent noisy-neighbor issues.
+
+#### Operational Notes
+
+- ENV:
+  - `API_KEY_SALT` (required in prod)
+  - `TENANT_RATE_LIMIT`, `TENANT_RATE_LIMIT_WINDOW`
+  - `BYPASS_AUTH=1` for tests/dev-only to bypass auth hook
+- Rotation procedure:
+  1) Create new key via admin API, deploy client with new key.
+  2) Revoke old key after cutover.
+- Observability: Audit logs + HTTP metrics provide visibility into actor actions and call volume. Add alerting for invalid key spikes.
+
+#### Rollout Plan
+
+- Migrate DB via Drizzle (tables above).
+- Seed a sample organisation, project, and default API key for local dev.
+- Enable middleware in API server with test bypass for CI.
+- Add admin UI wiring later; for now, use admin endpoints.
+
+#### Future Work
+
+- Full RBAC enforcement for user-authenticated routes using `org_members`.
+- Key-scoped rate limits by `scope` or endpoint class.
+- Audit log shipping to centralized immutable store.
+
+

--- a/packages/database/migrations/0000_fresh_betty_ross.sql
+++ b/packages/database/migrations/0000_fresh_betty_ross.sql
@@ -1,0 +1,268 @@
+CREATE TABLE IF NOT EXISTS "adjustments" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"metric" text NOT NULL,
+	"customer_ref" text NOT NULL,
+	"period_start" date NOT NULL,
+	"delta" numeric(20, 6) NOT NULL,
+	"reason" text NOT NULL,
+	"actor" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "alert_configs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"customer_ref" text,
+	"metric" text,
+	"type" text NOT NULL,
+	"threshold" numeric(20, 6) NOT NULL,
+	"action" text NOT NULL,
+	"config" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "alert_history" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"alert_config_id" uuid NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"customer_ref" text,
+	"metric" text,
+	"value" numeric(20, 6) NOT NULL,
+	"threshold" numeric(20, 6) NOT NULL,
+	"action" text NOT NULL,
+	"status" text DEFAULT 'triggered' NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"triggered_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"acknowledged_at" timestamp with time zone,
+	"resolved_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "api_keys" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organisation_id" uuid NOT NULL,
+	"project_id" uuid,
+	"secret_hash" text NOT NULL,
+	"prefix" text NOT NULL,
+	"last_four" text NOT NULL,
+	"name" text NOT NULL,
+	"scopes" text DEFAULT 'project:write,project:read' NOT NULL,
+	"expires_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"active" boolean DEFAULT true NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "audit_logs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organisation_id" uuid NOT NULL,
+	"project_id" uuid,
+	"actor_type" text NOT NULL,
+	"actor_id" text NOT NULL,
+	"action" text NOT NULL,
+	"resource_type" text,
+	"resource_id" text,
+	"ip" text,
+	"user_agent" text,
+	"meta" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "counters" (
+	"tenant_id" uuid NOT NULL,
+	"metric" text NOT NULL,
+	"customer_ref" text NOT NULL,
+	"period_start" date NOT NULL,
+	"period_end" date NOT NULL,
+	"agg_sum" numeric(20, 6) DEFAULT '0' NOT NULL,
+	"agg_max" numeric(20, 6) DEFAULT '0' NOT NULL,
+	"agg_last" numeric(20, 6),
+	"watermark_ts" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "counters_tenant_id_metric_customer_ref_period_start_pk" PRIMARY KEY("tenant_id","metric","customer_ref","period_start")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "events" (
+	"idempotency_key" text PRIMARY KEY NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"metric" text NOT NULL,
+	"customer_ref" text NOT NULL,
+	"resource_id" text,
+	"quantity" numeric(20, 6) NOT NULL,
+	"ts" timestamp with time zone NOT NULL,
+	"meta" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"source" text DEFAULT 'http' NOT NULL,
+	"inserted_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "price_mappings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"metric" text NOT NULL,
+	"aggregation" text NOT NULL,
+	"stripe_account" text NOT NULL,
+	"price_id" text NOT NULL,
+	"subscription_item_id" text,
+	"currency" text,
+	"active" boolean DEFAULT true NOT NULL,
+	CONSTRAINT "unique_active_mapping" UNIQUE NULLS NOT DISTINCT("tenant_id","metric","active")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "write_log" (
+	"tenant_id" uuid NOT NULL,
+	"stripe_account" text NOT NULL,
+	"subscription_item_id" text NOT NULL,
+	"period_start" date NOT NULL,
+	"pushed_total" numeric(20, 6) DEFAULT '0' NOT NULL,
+	"last_request_id" text,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "write_log_tenant_id_stripe_account_subscription_item_id_period_start_pk" PRIMARY KEY("tenant_id","stripe_account","subscription_item_id","period_start")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "reconciliation_reports" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"subscription_item_id" text NOT NULL,
+	"period_start" date NOT NULL,
+	"local_total" numeric(20, 6) NOT NULL,
+	"stripe_total" numeric(20, 6) NOT NULL,
+	"diff" numeric(20, 6) NOT NULL,
+	"status" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "simulation_batches" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"description" text,
+	"scenario_ids" jsonb NOT NULL,
+	"total_runs" integer NOT NULL,
+	"completed_runs" integer DEFAULT 0 NOT NULL,
+	"failed_runs" integer DEFAULT 0 NOT NULL,
+	"status" varchar(50) DEFAULT 'pending' NOT NULL,
+	"started_at" timestamp,
+	"completed_at" timestamp,
+	"summary" jsonb,
+	"created_by" varchar(255),
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "simulation_runs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"scenario_id" uuid,
+	"name" varchar(255),
+	"description" text,
+	"run_type" varchar(50) DEFAULT 'manual' NOT NULL,
+	"scenario_snapshot" jsonb NOT NULL,
+	"status" varchar(50) DEFAULT 'pending' NOT NULL,
+	"started_at" timestamp,
+	"completed_at" timestamp,
+	"duration_ms" integer,
+	"result" jsonb,
+	"comparison" jsonb,
+	"passed" boolean,
+	"error" jsonb,
+	"retry_count" integer DEFAULT 0 NOT NULL,
+	"triggered_by" varchar(255),
+	"metadata" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "simulation_scenarios" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"tenant_id" uuid NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"description" text,
+	"version" varchar(50) DEFAULT '1' NOT NULL,
+	"tags" jsonb DEFAULT '[]'::jsonb,
+	"model" jsonb NOT NULL,
+	"inputs" jsonb NOT NULL,
+	"expected" jsonb,
+	"tolerances" jsonb,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"created_by" varchar(255),
+	"updated_by" varchar(255)
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "organisations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "projects" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organisation_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "org_members" (
+	"organisation_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"role" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "org_members_organisation_id_user_id_pk" PRIMARY KEY("organisation_id","user_id")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_adjustments_tenant_period" ON "adjustments" ("tenant_id","period_start");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_adjustments_tenant_customer" ON "adjustments" ("tenant_id","customer_ref");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_alert_configs_tenant" ON "alert_configs" ("tenant_id","enabled");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_alert_configs_customer" ON "alert_configs" ("tenant_id","customer_ref","enabled");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_alert_configs_metric" ON "alert_configs" ("tenant_id","metric","enabled");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_alert_history_tenant" ON "alert_history" ("tenant_id","triggered_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_alert_history_status" ON "alert_history" ("status","tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_api_keys_org" ON "api_keys" ("organisation_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_api_keys_project" ON "api_keys" ("project_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_api_keys_org_name" ON "api_keys" ("organisation_id","name");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_audit_logs_org" ON "audit_logs" ("organisation_id","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_audit_logs_project" ON "audit_logs" ("project_id","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_counters_tenant_period" ON "counters" ("tenant_id","period_start");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_counters_customer" ON "counters" ("tenant_id","customer_ref","period_start");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_events_tenant_metric_customer_ts" ON "events" ("tenant_id","metric","customer_ref","ts");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_events_tenant_ts" ON "events" ("tenant_id","ts");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_price_mappings_tenant" ON "price_mappings" ("tenant_id","active");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_price_mappings_metric" ON "price_mappings" ("tenant_id","metric","active");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_write_log_tenant" ON "write_log" ("tenant_id","period_start");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_write_log_subscription_item" ON "write_log" ("subscription_item_id","period_start");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_reconciliation_tenant_period" ON "reconciliation_reports" ("tenant_id","period_start");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_reconciliation_status" ON "reconciliation_reports" ("status","tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_reconciliation_subscription_item" ON "reconciliation_reports" ("subscription_item_id","period_start");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "batches_tenant_idx" ON "simulation_batches" ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "batches_status_idx" ON "simulation_batches" ("status");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "batches_created_at_idx" ON "simulation_batches" ("created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "runs_tenant_idx" ON "simulation_runs" ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "runs_scenario_idx" ON "simulation_runs" ("scenario_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "runs_status_idx" ON "simulation_runs" ("status");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "runs_created_at_idx" ON "simulation_runs" ("created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "runs_type_idx" ON "simulation_runs" ("run_type");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "scenarios_tenant_idx" ON "simulation_scenarios" ("tenant_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "scenarios_name_idx" ON "simulation_scenarios" ("name");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "scenarios_active_idx" ON "simulation_scenarios" ("active");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "scenarios_created_at_idx" ON "simulation_scenarios" ("created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_organisations_slug" ON "organisations" ("slug");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_projects_org_slug" ON "projects" ("organisation_id","slug");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_org_members_org" ON "org_members" ("organisation_id");--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "alert_history" ADD CONSTRAINT "alert_history_alert_config_id_alert_configs_id_fk" FOREIGN KEY ("alert_config_id") REFERENCES "alert_configs"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "simulation_runs" ADD CONSTRAINT "simulation_runs_scenario_id_simulation_scenarios_id_fk" FOREIGN KEY ("scenario_id") REFERENCES "simulation_scenarios"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/database/migrations/meta/0000_snapshot.json
+++ b/packages/database/migrations/meta/0000_snapshot.json
@@ -1,0 +1,1608 @@
+{
+  "id": "f146046b-a67f-47ae-a518-a23ca8766f48",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "adjustments": {
+      "name": "adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_ref": {
+          "name": "customer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delta": {
+          "name": "delta",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_adjustments_tenant_period": {
+          "name": "idx_adjustments_tenant_period",
+          "columns": [
+            "tenant_id",
+            "period_start"
+          ],
+          "isUnique": false
+        },
+        "idx_adjustments_tenant_customer": {
+          "name": "idx_adjustments_tenant_customer",
+          "columns": [
+            "tenant_id",
+            "customer_ref"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "alert_configs": {
+      "name": "alert_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_ref": {
+          "name": "customer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_alert_configs_tenant": {
+          "name": "idx_alert_configs_tenant",
+          "columns": [
+            "tenant_id",
+            "enabled"
+          ],
+          "isUnique": false
+        },
+        "idx_alert_configs_customer": {
+          "name": "idx_alert_configs_customer",
+          "columns": [
+            "tenant_id",
+            "customer_ref",
+            "enabled"
+          ],
+          "isUnique": false
+        },
+        "idx_alert_configs_metric": {
+          "name": "idx_alert_configs_metric",
+          "columns": [
+            "tenant_id",
+            "metric",
+            "enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "alert_history": {
+      "name": "alert_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_config_id": {
+          "name": "alert_config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_ref": {
+          "name": "customer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'triggered'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_alert_history_tenant": {
+          "name": "idx_alert_history_tenant",
+          "columns": [
+            "tenant_id",
+            "triggered_at"
+          ],
+          "isUnique": false
+        },
+        "idx_alert_history_status": {
+          "name": "idx_alert_history_status",
+          "columns": [
+            "status",
+            "tenant_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alert_history_alert_config_id_alert_configs_id_fk": {
+          "name": "alert_history_alert_config_id_alert_configs_id_fk",
+          "tableFrom": "alert_history",
+          "tableTo": "alert_configs",
+          "columnsFrom": [
+            "alert_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_four": {
+          "name": "last_four",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'project:write,project:read'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_api_keys_org": {
+          "name": "idx_api_keys_org",
+          "columns": [
+            "organisation_id"
+          ],
+          "isUnique": false
+        },
+        "idx_api_keys_project": {
+          "name": "idx_api_keys_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "uq_api_keys_org_name": {
+          "name": "uq_api_keys_org_name",
+          "columns": [
+            "organisation_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_org": {
+          "name": "idx_audit_logs_org",
+          "columns": [
+            "organisation_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_logs_project": {
+          "name": "idx_audit_logs_project",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "counters": {
+      "name": "counters",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_ref": {
+          "name": "customer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agg_sum": {
+          "name": "agg_sum",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "agg_max": {
+          "name": "agg_max",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "agg_last": {
+          "name": "agg_last",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watermark_ts": {
+          "name": "watermark_ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_counters_tenant_period": {
+          "name": "idx_counters_tenant_period",
+          "columns": [
+            "tenant_id",
+            "period_start"
+          ],
+          "isUnique": false
+        },
+        "idx_counters_customer": {
+          "name": "idx_counters_customer",
+          "columns": [
+            "tenant_id",
+            "customer_ref",
+            "period_start"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "counters_tenant_id_metric_customer_ref_period_start_pk": {
+          "name": "counters_tenant_id_metric_customer_ref_period_start_pk",
+          "columns": [
+            "tenant_id",
+            "metric",
+            "customer_ref",
+            "period_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_ref": {
+          "name": "customer_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http'"
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_tenant_metric_customer_ts": {
+          "name": "idx_events_tenant_metric_customer_ts",
+          "columns": [
+            "tenant_id",
+            "metric",
+            "customer_ref",
+            "ts"
+          ],
+          "isUnique": false
+        },
+        "idx_events_tenant_ts": {
+          "name": "idx_events_tenant_ts",
+          "columns": [
+            "tenant_id",
+            "ts"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "price_mappings": {
+      "name": "price_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregation": {
+          "name": "aggregation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_account": {
+          "name": "stripe_account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_item_id": {
+          "name": "subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_price_mappings_tenant": {
+          "name": "idx_price_mappings_tenant",
+          "columns": [
+            "tenant_id",
+            "active"
+          ],
+          "isUnique": false
+        },
+        "idx_price_mappings_metric": {
+          "name": "idx_price_mappings_metric",
+          "columns": [
+            "tenant_id",
+            "metric",
+            "active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_active_mapping": {
+          "name": "unique_active_mapping",
+          "nullsNotDistinct": true,
+          "columns": [
+            "tenant_id",
+            "metric",
+            "active"
+          ]
+        }
+      }
+    },
+    "write_log": {
+      "name": "write_log",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_account": {
+          "name": "stripe_account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_item_id": {
+          "name": "subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pushed_total": {
+          "name": "pushed_total",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "last_request_id": {
+          "name": "last_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_write_log_tenant": {
+          "name": "idx_write_log_tenant",
+          "columns": [
+            "tenant_id",
+            "period_start"
+          ],
+          "isUnique": false
+        },
+        "idx_write_log_subscription_item": {
+          "name": "idx_write_log_subscription_item",
+          "columns": [
+            "subscription_item_id",
+            "period_start"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "write_log_tenant_id_stripe_account_subscription_item_id_period_start_pk": {
+          "name": "write_log_tenant_id_stripe_account_subscription_item_id_period_start_pk",
+          "columns": [
+            "tenant_id",
+            "stripe_account",
+            "subscription_item_id",
+            "period_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "reconciliation_reports": {
+      "name": "reconciliation_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_item_id": {
+          "name": "subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_total": {
+          "name": "local_total",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_total": {
+          "name": "stripe_total",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diff": {
+          "name": "diff",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_reconciliation_tenant_period": {
+          "name": "idx_reconciliation_tenant_period",
+          "columns": [
+            "tenant_id",
+            "period_start"
+          ],
+          "isUnique": false
+        },
+        "idx_reconciliation_status": {
+          "name": "idx_reconciliation_status",
+          "columns": [
+            "status",
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "idx_reconciliation_subscription_item": {
+          "name": "idx_reconciliation_subscription_item",
+          "columns": [
+            "subscription_item_id",
+            "period_start"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "simulation_batches": {
+      "name": "simulation_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scenario_ids": {
+          "name": "scenario_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_runs": {
+          "name": "completed_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_runs": {
+          "name": "failed_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "batches_tenant_idx": {
+          "name": "batches_tenant_idx",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "batches_status_idx": {
+          "name": "batches_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "batches_created_at_idx": {
+          "name": "batches_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "simulation_runs": {
+      "name": "simulation_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenario_id": {
+          "name": "scenario_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_type": {
+          "name": "run_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "scenario_snapshot": {
+          "name": "scenario_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comparison": {
+          "name": "comparison",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runs_tenant_idx": {
+          "name": "runs_tenant_idx",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "runs_scenario_idx": {
+          "name": "runs_scenario_idx",
+          "columns": [
+            "scenario_id"
+          ],
+          "isUnique": false
+        },
+        "runs_status_idx": {
+          "name": "runs_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "runs_created_at_idx": {
+          "name": "runs_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "runs_type_idx": {
+          "name": "runs_type_idx",
+          "columns": [
+            "run_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "simulation_runs_scenario_id_simulation_scenarios_id_fk": {
+          "name": "simulation_runs_scenario_id_simulation_scenarios_id_fk",
+          "tableFrom": "simulation_runs",
+          "tableTo": "simulation_scenarios",
+          "columnsFrom": [
+            "scenario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "simulation_scenarios": {
+      "name": "simulation_scenarios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "model": {
+          "name": "model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected": {
+          "name": "expected",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tolerances": {
+          "name": "tolerances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "scenarios_tenant_idx": {
+          "name": "scenarios_tenant_idx",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": false
+        },
+        "scenarios_name_idx": {
+          "name": "scenarios_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "scenarios_active_idx": {
+          "name": "scenarios_active_idx",
+          "columns": [
+            "active"
+          ],
+          "isUnique": false
+        },
+        "scenarios_created_at_idx": {
+          "name": "scenarios_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "organisations": {
+      "name": "organisations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_organisations_slug": {
+          "name": "uq_organisations_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_projects_org_slug": {
+          "name": "uq_projects_org_slug",
+          "columns": [
+            "organisation_id",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_members_org": {
+          "name": "idx_org_members_org",
+          "columns": [
+            "organisation_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_organisation_id_user_id_pk": {
+          "name": "org_members_organisation_id_user_id_pk",
+          "columns": [
+            "organisation_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -1,1 +1,13 @@
-{"version":"5","dialect":"pg","entries":[]}
+{
+  "version": "5",
+  "dialect": "pg",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "5",
+      "when": 1757469128801,
+      "tag": "0000_fresh_betty_ross",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/database/src/schema/api-keys.ts
+++ b/packages/database/src/schema/api-keys.ts
@@ -1,0 +1,34 @@
+/**
+ * API Keys table schema
+ */
+
+import { pgTable, uuid, text, timestamp, boolean, index, uniqueIndex } from 'drizzle-orm/pg-core';
+
+export const apiKeys = pgTable('api_keys', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  organisationId: uuid('organisation_id').notNull(),
+  projectId: uuid('project_id'),
+  // Stored as HMAC(keyId + secret) or a hashed secret with per-key salt
+  secretHash: text('secret_hash').notNull(),
+  prefix: text('prefix').notNull(),
+  lastFour: text('last_four').notNull(),
+  name: text('name').notNull(),
+  scopes: text('scopes').notNull().default('project:write,project:read'),
+  expiresAt: timestamp('expires_at', { withTimezone: true }),
+  revokedAt: timestamp('revoked_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  active: boolean('active').notNull().default(true),
+}, (table) => {
+  return {
+    orgIdx: index('idx_api_keys_org').on(table.organisationId),
+    projectIdx: index('idx_api_keys_project').on(table.projectId),
+    // Optional uniqueness on (org, name)
+    orgNameUq: uniqueIndex('uq_api_keys_org_name').on(table.organisationId, table.name),
+  };
+});
+
+export type ApiKey = typeof apiKeys.$inferSelect;
+export type NewApiKey = typeof apiKeys.$inferInsert;
+
+

--- a/packages/database/src/schema/audit-logs.ts
+++ b/packages/database/src/schema/audit-logs.ts
@@ -1,0 +1,30 @@
+/**
+ * Audit logs schema
+ */
+
+import { pgTable, uuid, text, timestamp, jsonb, index } from 'drizzle-orm/pg-core';
+
+export const auditLogs = pgTable('audit_logs', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  organisationId: uuid('organisation_id').notNull(),
+  projectId: uuid('project_id'),
+  actorType: text('actor_type').notNull(), // api_key | user | system
+  actorId: text('actor_id').notNull(),
+  action: text('action').notNull(),
+  resourceType: text('resource_type'),
+  resourceId: text('resource_id'),
+  ip: text('ip'),
+  userAgent: text('user_agent'),
+  meta: jsonb('meta').notNull().default({}),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+}, (table) => {
+  return {
+    orgIdx: index('idx_audit_logs_org').on(table.organisationId, table.createdAt),
+    projectIdx: index('idx_audit_logs_project').on(table.projectId, table.createdAt),
+  };
+});
+
+export type AuditLog = typeof auditLogs.$inferSelect;
+export type NewAuditLog = typeof auditLogs.$inferInsert;
+
+

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -10,3 +10,8 @@ export * from './write-log';
 export * from './reconciliation';
 export * from './alerts';
 export * from './simulations';
+export * from './organisations';
+export * from './projects';
+export * from './api-keys';
+export * from './roles';
+export * from './audit-logs';

--- a/packages/database/src/schema/organisations.ts
+++ b/packages/database/src/schema/organisations.ts
@@ -1,0 +1,22 @@
+/**
+ * Organisations table schema
+ */
+
+import { pgTable, uuid, text, timestamp, uniqueIndex } from 'drizzle-orm/pg-core';
+
+export const organisations = pgTable('organisations', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: text('name').notNull(),
+  slug: text('slug').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (table) => {
+  return {
+    slugIdx: uniqueIndex('uq_organisations_slug').on(table.slug),
+  };
+});
+
+export type Organisation = typeof organisations.$inferSelect;
+export type NewOrganisation = typeof organisations.$inferInsert;
+
+

--- a/packages/database/src/schema/projects.ts
+++ b/packages/database/src/schema/projects.ts
@@ -1,0 +1,23 @@
+/**
+ * Projects table schema
+ */
+
+import { pgTable, uuid, text, timestamp, uniqueIndex } from 'drizzle-orm/pg-core';
+
+export const projects = pgTable('projects', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  organisationId: uuid('organisation_id').notNull(),
+  name: text('name').notNull(),
+  slug: text('slug').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (table) => {
+  return {
+    slugIdx: uniqueIndex('uq_projects_org_slug').on(table.organisationId, table.slug),
+  };
+});
+
+export type Project = typeof projects.$inferSelect;
+export type NewProject = typeof projects.$inferInsert;
+
+

--- a/packages/database/src/schema/roles.ts
+++ b/packages/database/src/schema/roles.ts
@@ -1,0 +1,23 @@
+/**
+ * Roles & memberships schema
+ */
+
+import { pgTable, uuid, text, timestamp, index, primaryKey } from 'drizzle-orm/pg-core';
+
+export const orgMembers = pgTable('org_members', {
+  organisationId: uuid('organisation_id').notNull(),
+  userId: uuid('user_id').notNull(),
+  role: text('role').notNull(), // owner | maintainer | viewer
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (table) => {
+  return {
+    pk: primaryKey({ columns: [table.organisationId, table.userId] }),
+    orgIdx: index('idx_org_members_org').on(table.organisationId),
+  };
+});
+
+export type OrgMember = typeof orgMembers.$inferSelect;
+export type NewOrgMember = typeof orgMembers.$inferInsert;
+
+

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -1,0 +1,57 @@
+import { db } from './client';
+import { organisations } from './schema/organisations';
+import { projects } from './schema/projects';
+import { apiKeys } from './schema/api-keys';
+import { orgMembers } from './schema/roles';
+import { randomBytes, createHmac } from 'crypto';
+
+async function main() {
+  const orgId = cryptoRandomUuid();
+  const projectId = cryptoRandomUuid();
+
+  await db.insert(organisations).values({ id: orgId, name: 'Acme Inc', slug: 'acme' }).onConflictDoNothing();
+  await db.insert(projects).values({ id: projectId, organisationId: orgId, name: 'Acme Default', slug: 'default' }).onConflictDoNothing();
+
+  // Demo API key generation
+  const { apiKey, prefix, last4, secretHash } = generateApiKeyHash('sm_demo');
+  await db.insert(apiKeys).values({ organisationId: orgId, projectId, name: 'Default Key', prefix, lastFour: last4, secretHash }).onConflictDoNothing();
+
+  // Demo org member
+  await db.insert(orgMembers).values({ organisationId: orgId, userId: cryptoRandomUuid(), role: 'owner' }).onConflictDoNothing();
+
+  console.log('Seed complete. Demo API key:', apiKey);
+}
+
+function cryptoRandomUuid(): string {
+  // Simple RFC4122 v4 UUID from Node 18+ crypto
+  const buf = randomBytes(16);
+  buf[6] = (buf[6] & 0x0f) | 0x40;
+  buf[8] = (buf[8] & 0x3f) | 0x80;
+  const hex = buf.toString('hex');
+  return (
+    hex.substring(0, 8) + '-' +
+    hex.substring(8, 12) + '-' +
+    hex.substring(12, 16) + '-' +
+    hex.substring(16, 20) + '-' +
+    hex.substring(20)
+  );
+}
+
+function generateApiKeyHash(prefixBase: string) {
+  const prefix = `${prefixBase}_${randomBytes(3).toString('hex')}`;
+  const secret = randomBytes(24).toString('base64url');
+  const apiKey = `${prefix}.${secret}`;
+  const last4 = secret.slice(-4);
+  const secretHash = createHmac('sha256', getKeyDerivationSalt())
+    .update(apiKey)
+    .digest('base64url');
+  return { apiKey, prefix, last4, secretHash };
+}
+
+function getKeyDerivationSalt(): string {
+  return process.env.API_KEY_SALT || 'dev-api-key-salt';
+}
+
+main().then(() => process.exit(0)).catch((err) => { console.error(err); process.exit(1); });
+
+


### PR DESCRIPTION
## What

- Add Drizzle schemas: organisations, projects, api_keys, org_members, audit_logs
- Generate migrations and seed sample tenant + API key
- Implement API-key auth (HMAC verification), attach tenant context, per-tenant/project rate limits
- Persist audit logs on response
- Admin endpoints to create/rotate/revoke API keys
- Add ADR 0001 documenting design & security trade-offs

- Tests: auth middleware, admin lifecycle, E2E simulations stabilized (27 passed)

## Why

- Secure, multi-tenant API with RBAC groundwork. Enables safe key rotation/revocation, per-tenant isolation and abuse protection, and adds auditability for compliance.

## Test Plan
### Setup DB:

- cd packages/database && pnpm migrate && pnpm seed

### API tests:

- cd apps/api && BYPASS_AUTH=1 pnpm test # 27 passed locally

### Monorepo build (pre-push hook):

- pnpm -w build # success

### Workers/admin-ui/simulator-cli tests ran green under pre-push