### PR TITLE
docs(ops): add ALERTS.md and PromQL rules; add Alertmanager config; link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ helm install stripemeter ./charts/stripemeter
 - Structured logging
 - Distributed tracing
 - Health check endpoints
+- Alerts: see [ops/ALERTS.md](ops/ALERTS.md)
 
 ## Security & Compliance
 

--- a/ops/ALERTS.md
+++ b/ops/ALERTS.md
@@ -1,0 +1,78 @@
+## Alerting Rules (Prometheus)
+
+This document defines baseline alerting rules for StripeMeter. Each alert includes a brief next action.
+
+Copy the rules block into your Prometheus `rule_files` and run `promtool check rules` before applying.
+
+```yaml
+groups:
+  - name: stripemeter.rules
+    rules:
+      # Drift absolute exceeds epsilon for 15 minutes
+      - alert: ReconciliationDriftAbsHigh
+        expr: max_over_time(reconciliation_diff_abs[15m]) > 0.0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Reconciliation absolute drift above epsilon"
+          description: "Absolute drift between local and Stripe exceeds epsilon for 15m. value={{ $value }}"
+          runbook: "Inspect reconciliation reports; follow RECONCILIATION.md steps 1–4."
+
+      # Drift percentage exceeds threshold for 15 minutes
+      - alert: ReconciliationDriftPctHigh
+        expr: max_over_time(reconciliation_diff_pct[15m]) > 0.005
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Reconciliation percentage drift above threshold"
+          description: "Percentage drift (|local - stripe| / stripe) > 0.5% for 15m. value={{ $value }}"
+          runbook: "Backfill or adjust per RECONCILIATION.md for affected item(s)."
+
+      # Queue lag above threshold (requires exporter of BullMQ/Redis lag)
+      - alert: IngestionQueueLagHigh
+        expr: max_over_time(queue_lag_seconds{queue=~"aggregation|writer"}[15m]) > 60
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Queue lag over 60s"
+          description: "Background queue lag above 60s for 15m. value={{ $value }}"
+          runbook: "Check Redis, worker replicas, backlog; scale workers or unstick jobs."
+
+      # Ingest latency p95 above SLO
+      - alert: IngestLatencyHighP95
+        expr: histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{route="/v1/events/ingest"}[5m]))) > 0.2
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Ingest p95 latency over 200ms"
+          description: "POST /v1/events/ingest p95 > 200ms for 15m. value={{ $value }}"
+          runbook: "Check API/DB/Redis; scale API or tune batch sizes."
+
+      # HTTP 5xx rate above threshold
+      - alert: Http5xxRateHigh
+        expr: sum by (route) (rate(http_requests_total{status_code=~"5.."}[5m])) > 0.1
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "HTTP 5xx rate high"
+          description: "5xx error rate > 0.1 req/s over 5m for 15m. route={{ $labels.route }} value={{ $value }}"
+          runbook: "Check deploys/logs/upstreams; roll back or hotfix."
+```
+
+Notes
+- Metrics used are based on built-in exporters:
+  - `http_request_duration_seconds_bucket`, `http_requests_total` from API
+  - `reconciliation_diff_abs`, `reconciliation_diff_pct` are placeholders; wire to reconciler metrics or Redis-exported gauges.
+  - `queue_lag_seconds` is a placeholder for BullMQ/Redis consumer lag. Add an exporter or custom gauge.
+- Coordinate thresholds with `RECONCILIATION.md` and production SLOs in `project-principles.md`.
+
+### Alertmanager Example
+
+See `ops/alertmanager/alertmanager.yml` for a minimal route/receiver.
+
+

--- a/ops/alertmanager/alertmanager.yml
+++ b/ops/alertmanager/alertmanager.yml
@@ -1,0 +1,27 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: default
+  group_by: [alertname]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+receivers:
+  - name: default
+    webhook_configs:
+      - url: http://alert-receiver.local/alerts
+        send_resolved: true
+
+# Example: to use email instead of webhook, replace receiver with:
+# receivers:
+#   - name: default
+#     email_configs:
+#       - to: oncall@example.com
+#         from: alerts@example.com
+#         smarthost: smtp.example.com:587
+#         auth_username: alerts@example.com
+#         auth_identity: alerts@example.com
+#         auth_password: ${SMTP_PASSWORD}
+

--- a/ops/alerts.rules.yml
+++ b/ops/alerts.rules.yml
@@ -1,0 +1,53 @@
+groups:
+  - name: stripemeter.rules
+    rules:
+      - alert: ReconciliationDriftAbsHigh
+        expr: max_over_time(reconciliation_diff_abs[15m]) > 1.0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Reconciliation absolute drift above epsilon"
+          description: "Absolute drift between local and Stripe exceeds epsilon for 15m. value={{ $value }}"
+          runbook: "Inspect reconciliation reports; follow RECONCILIATION.md steps 1–4."
+
+      - alert: ReconciliationDriftPctHigh
+        expr: max_over_time(reconciliation_diff_pct[15m]) > 0.005
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Reconciliation percentage drift above threshold"
+          description: "Percentage drift (|local - stripe| / stripe) > 0.5% for 15m. value={{ $value }}"
+          runbook: "Backfill or adjust per RECONCILIATION.md for affected item(s)."
+
+      - alert: IngestionQueueLagHigh
+        expr: max_over_time(queue_lag_seconds{queue=~"aggregation|writer"}[15m]) > 60
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Queue lag over 60s"
+          description: "Background queue lag above 60s for 15m. value={{ $value }}"
+          runbook: "Check Redis, worker replicas, backlog; scale workers or unstick jobs."
+
+      - alert: IngestLatencyHighP95
+        expr: histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{route="/v1/events/ingest"}[5m]))) > 0.2
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Ingest p95 latency over 200ms"
+          description: "POST /v1/events/ingest p95 > 200ms for 15m. value={{ $value }}"
+          runbook: "Check API/DB/Redis; scale API or tune batch sizes."
+
+      - alert: Http5xxRateHigh
+        expr: sum by (route) (rate(http_requests_total{status_code=~"5.."}[5m])) > 0.1
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "HTTP 5xx rate high"
+          description: "5xx error rate > 0.1 req/s over 5m for 15m. route={{ $labels.route }} value={{ $value }}"
+          runbook: "Check deploys/logs/upstreams; roll back or hotfix."
+


### PR DESCRIPTION
**What**
- Add ops/ALERTS.md with PromQL rules for drift detection, queue lag, ingest latency, and HTTP 5xx rate
- Add ops/alertmanager/alertmanager.yml with default route/receiver configuration
- Add ops/alerts.rules.yml for direct Prometheus inclusion
- Link alerts documentation from README Observability section

**Why**
- Teams need actionable alerts to catch drift and ingestion issues early
- Provides baseline alerting rules with mini runbooks for quick incident response
- Validates with promtool check rules for production readiness

**Test Plan**
- Validated Prometheus rules syntax: `docker run --rm --entrypoint /bin/promtool -v $(pwd):/work prom/prometheus:latest check rules /work/ops/alerts.rules.yml`
- Output: SUCCESS: 5 rules found
- All acceptance criteria met: promtool passes, one-line runbooks included, Alertmanager config provided

**Related Issues**
- closes ops/docs: ALERTS.md (PromQL rules for drift, queue lag, 5xx, latency) #56

