### PR TITLE
feat: add usage history api

### DIFF
--- a/apps/api/src/routes/usage.test.ts
+++ b/apps/api/src/routes/usage.test.ts
@@ -54,6 +54,53 @@ describe('Usage API', () => {
     expect(body).toHaveProperty('subtotal');
     expect(body).toHaveProperty('total');
   });
+
+  describe('POST /v1/usage/history', () => {
+    const tenantId = '00000000-0000-0000-0000-000000000000';
+    const customerRef = 'cus_TEST';
+    const metric = 'api_calls';
+    const timestamps = [
+      '2025-09-03T03:03:03Z',
+    ];
+    const events: any = [];
+    const quantities = [100];
+    quantities.forEach(q => {
+      timestamps.forEach(ts => {
+        events.push({
+          tenantId,
+          metric: 'api_calls',
+          customerRef: 'cus_TEST001',
+          quantity: q,
+          ts: new Date(ts).toISOString(),
+        });
+      });
+    });
+
+
+    beforeAll(async () => {
+      await server.inject({
+        method: 'POST',
+        url: '/v1/events/ingest',
+        payload: { events },
+      });
+    });
+    it('should return usage history correct response shape', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/v1/usage/history',
+        query: {
+          tenantId,
+          customerRef,
+          metric,
+          periodStart: '2025-09-01T00:00:00Z',
+          periodEnd: '2025-10-31T23:59:59.999Z',
+          step: 'month',
+        },
+      });
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty('usage');
+      expect(Array.isArray(body.usage)).toBe(true);
+    });
+  });
 });
-
-

--- a/packages/core/src/schemas/validation.ts
+++ b/packages/core/src/schemas/validation.ts
@@ -26,6 +26,15 @@ export const usageEventSchema = z.object({
   source: z.enum(['sdk', 'http', 'etl', 'import', 'system']).optional(),
 });
 
+export const getUsageHistoryQuerySchema = z.object({
+  tenantId: uuidSchema,
+  customerRef: z.string().min(1).max(255),
+  metric: z.string().min(1).max(100),
+  periodStart: isoDateTimeSchema,
+  periodEnd: isoDateTimeSchema,
+  step: z.enum(['day', 'month']).optional().default('month'),
+});
+
 // Batch event ingestion schema
 export const ingestEventRequestSchema = z.object({
   events: z.array(usageEventSchema).min(1).max(1000),
@@ -104,6 +113,7 @@ export const alertConfigSchema = z.object({
 
 // Type exports
 export type UsageEventInput = z.infer<typeof usageEventSchema>;
+export type GetUsageHistoryQueryInput = z.infer<typeof getUsageHistoryQuerySchema>;
 export type IngestEventRequestInput = z.infer<typeof ingestEventRequestSchema>;
 export type GetEventsQueryInput = z.infer<typeof getEventsQuerySchema>;
 export type AdjustmentRequestInput = z.infer<typeof adjustmentRequestSchema>;

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -117,6 +117,19 @@ export interface UsageResponse {
   }>;
 }
 
+
+
+export interface GetUsageHistoryResponse {
+  usage: Array<{
+    ts: string;
+    value: number;
+  }>;
+  errors?: Array<{
+    index: number;
+    error: string;
+  }>;
+}
+
 export interface ReconciliationResponse {
   period: string;
   reports: ReconciliationReport[];


### PR DESCRIPTION
**What**
- Add usage history api

**Why**
- to get usage series in time bucket

**Test Plan**
- sample request/ response
```
GET http://localhost:3000/v1/usage/history?tenantId=9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d&customerRef=cus_TEST001&metric=api_calls&periodStart=2025-09-01T00%3A00%3A00Z&periodEnd=2025-09-30T23%3A59%3A59Z&step=day

{
  "usage": [
    {
      "ts": "2025-09-04T00:00:00.000Z",
      "value": 150
    },
    {
      "ts": "2025-09-05T00:00:00.000Z",
      "value": 100
    }
  ]
}
```


**Related Issues**
- closes #61 
