### PR TITLE
api: relax tenantId validation from uuid to string for better DX

### DIFF
--- a/apps/api/src/routes/events.test.ts
+++ b/apps/api/src/routes/events.test.ts
@@ -81,6 +81,28 @@ describe('Events API', () => {
       expect(['accepted','duplicate','error']).toContain(body.results[0].status);
     });
 
+    it('should accept events with non-UUID tenantId', async () => {
+      const events = [
+        {
+          tenantId: 'demo-tenant',
+          metric: 'api_calls',
+          customerRef: 'cus_TEST_NONUUID',
+          quantity: 1,
+          ts: new Date().toISOString(),
+        },
+      ];
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/v1/events/ingest',
+        payload: { events },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.accepted + body.duplicates).toBe(events.length);
+    });
+
     it('should handle duplicate events with idempotency', async () => {
       const idempotencyKey = 'evt_test_duplicate_001';
       const event = {

--- a/apps/api/src/routes/events.ts
+++ b/apps/api/src/routes/events.ts
@@ -13,6 +13,7 @@ import {
   type GetEventsResponse,
 } from '@stripemeter/core';
 import { Queue } from 'bullmq';
+import { warnIfNonUuidTenantId } from '../utils/logger';
 
 export const eventsRoutes: FastifyPluginAsync = async (server) => {
   // Lazily import database to play well with test mocks
@@ -184,6 +185,8 @@ export const eventsRoutes: FastifyPluginAsync = async (server) => {
       const aggregationJobs = new Map<string, any>();
 
       for (const event of inserted) {
+        // Soft guidance: log if tenantId not UUID
+        warnIfNonUuidTenantId(server.log, event.tenantId);
         const periodStart = new Date(event.ts);
         periodStart.setUTCDate(1);
         periodStart.setUTCHours(0, 0, 0, 0);
@@ -235,7 +238,7 @@ export const eventsRoutes: FastifyPluginAsync = async (server) => {
         type: 'object',
         required: ['tenantId', 'metric', 'periodStart', 'reason'],
         properties: {
-          tenantId: { type: 'string', format: 'uuid' },
+          tenantId: { type: 'string' },
           metric: { type: 'string' },
           customerRef: { type: 'string' },
           periodStart: { type: 'string', format: 'date' },
@@ -270,7 +273,7 @@ export const eventsRoutes: FastifyPluginAsync = async (server) => {
         type: 'object',
         required: ['tenantId'],
         properties: {
-          tenantId: { type: 'string', format: 'uuid' },
+          tenantId: { type: 'string' },
           metric: { type: 'string' },
           customerRef: { type: 'string' },
           source: { type: 'string' },

--- a/apps/api/src/routes/reconciliation.ts
+++ b/apps/api/src/routes/reconciliation.ts
@@ -31,7 +31,7 @@ export const reconciliationRoutes: FastifyPluginAsync = async (server) => {
         type: 'object',
         required: ['tenantId'],
         properties: {
-          tenantId: { type: 'string', format: 'uuid' },
+          tenantId: { type: 'string' },
         },
       },
       response: {
@@ -120,7 +120,7 @@ export const reconciliationRoutes: FastifyPluginAsync = async (server) => {
         type: 'object',
         required: ['tenantId'],
         properties: {
-          tenantId: { type: 'string', format: 'uuid' },
+          tenantId: { type: 'string' },
         },
       },
       response: {
@@ -156,7 +156,7 @@ export const reconciliationRoutes: FastifyPluginAsync = async (server) => {
         type: 'object',
         required: ['tenantId', 'periodStart', 'periodEnd'],
         properties: {
-          tenantId: { type: 'string', format: 'uuid' },
+          tenantId: { type: 'string' },
           periodStart: { type: 'string', pattern: '^\\d{4}-\\d{2}$' },
           periodEnd: { type: 'string', pattern: '^\\d{4}-\\d{2}$' },
         },

--- a/apps/api/src/routes/usage.ts
+++ b/apps/api/src/routes/usage.ts
@@ -29,7 +29,7 @@ export const usageRoutes: FastifyPluginAsync = async (server) => {
         type: 'object',
         required: ['tenantId', 'customerRef'],
         properties: {
-          tenantId: { type: 'string', format: 'uuid' },
+          tenantId: { type: 'string' },
           customerRef: { type: 'string' },
         },
       },
@@ -139,7 +139,7 @@ export const usageRoutes: FastifyPluginAsync = async (server) => {
         type: 'object',
         required: ['tenantId', 'customerRef'],
         properties: {
-          tenantId: { type: 'string', format: 'uuid' },
+          tenantId: { type: 'string' },
           customerRef: { type: 'string' },
           periodStart: { type: 'string', format: 'date' },
           periodEnd: { type: 'string', format: 'date' },
@@ -296,7 +296,7 @@ export const usageRoutes: FastifyPluginAsync = async (server) => {
         type: 'object',
         required: ['tenantId', 'customerRef', 'metric', 'periodStart', 'periodEnd', 'step'],
         properties: {
-          tenantId: { type: 'string', format: 'uuid' },
+          tenantId: { type: 'string' },
           customerRef: { type: 'string' },
           metric: { type: 'string' },
           periodStart: { type: 'string', format: 'date-time' },

--- a/apps/api/src/utils/logger.ts
+++ b/apps/api/src/utils/logger.ts
@@ -50,3 +50,10 @@ export function logAudit(serverOrRequest: any, event: {
   const l = serverOrRequest && serverOrRequest.log ? serverOrRequest.log : logger;
   l.info({ audit: event }, 'audit');
 }
+
+export function warnIfNonUuidTenantId(logger: any, tenantId: string) {
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(tenantId);
+  if (!isUuid) {
+    try { logger?.warn?.({ tenantId }, 'non-uuid tenantId used'); } catch { /* noop */ }
+  }
+}

--- a/packages/core/src/schemas/validation.ts
+++ b/packages/core/src/schemas/validation.ts
@@ -10,12 +10,12 @@ const isoDateTimeSchema = z.string().refine(
   { message: 'Invalid ISO 8601 date-time format' }
 );
 
-// UUID validation
-const uuidSchema = z.string().uuid();
+// TenantId: relax from UUID to string for DX; still allow UUIDs but don't require
+const tenantIdSchema = z.string().min(1);
 
 // Usage event schema
 export const usageEventSchema = z.object({
-  tenantId: uuidSchema,
+  tenantId: tenantIdSchema,
   metric: z.string().min(1).max(100),
   customerRef: z.string().min(1).max(255),
   resourceId: z.string().max(255).optional(),
@@ -27,7 +27,7 @@ export const usageEventSchema = z.object({
 });
 
 export const getUsageHistoryQuerySchema = z.object({
-  tenantId: uuidSchema,
+  tenantId: tenantIdSchema,
   customerRef: z.string().min(1).max(255),
   metric: z.string().min(1).max(100),
   periodStart: isoDateTimeSchema,
@@ -42,7 +42,7 @@ export const ingestEventRequestSchema = z.object({
 
 // Get Event List Query schema
 export const getEventsQuerySchema = z.object({
-  tenantId: uuidSchema,
+  tenantId: tenantIdSchema,
   metric: z.string().min(1).max(100).optional(),
   customerRef: z.string().min(1).max(255).optional(),
   source: z.enum(['sdk', 'http', 'etl', 'import', 'system']).optional(),
@@ -56,7 +56,7 @@ export const getEventsQuerySchema = z.object({
 
 // Adjustment schema
 export const adjustmentRequestSchema = z.object({
-  tenantId: uuidSchema,
+  tenantId: tenantIdSchema,
   metric: z.string().min(1).max(100),
   customerRef: z.string().min(1).max(255),
   periodStart: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
@@ -66,7 +66,7 @@ export const adjustmentRequestSchema = z.object({
 
 // Backfill request schema
 export const backfillRequestSchema = z.object({
-  tenantId: uuidSchema,
+  tenantId: tenantIdSchema,
   metric: z.string().min(1).max(100),
   customerRef: z.string().min(1).max(255).optional(),
   periodStart: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
@@ -81,7 +81,7 @@ export const backfillRequestSchema = z.object({
 
 // Projection request schema
 export const projectionRequestSchema = z.object({
-  tenantId: uuidSchema,
+  tenantId: tenantIdSchema,
   customerRef: z.string().min(1).max(255),
   periodStart: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
   periodEnd: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
@@ -89,7 +89,7 @@ export const projectionRequestSchema = z.object({
 
 // Price mapping schema
 export const priceMappingSchema = z.object({
-  tenantId: uuidSchema,
+  tenantId: tenantIdSchema,
   metric: z.string().min(1).max(100),
   aggregation: z.enum(['sum', 'max', 'last']),
   stripeAccount: z.string().startsWith('acct_'),
@@ -101,7 +101,7 @@ export const priceMappingSchema = z.object({
 
 // Alert configuration schema
 export const alertConfigSchema = z.object({
-  tenantId: uuidSchema,
+  tenantId: tenantIdSchema,
   customerRef: z.string().min(1).max(255).optional(),
   metric: z.string().min(1).max(100).optional(),
   type: z.enum(['threshold', 'spike', 'budget']),


### PR DESCRIPTION
**What**
- Relax tenantId validation from UUID to string across all API routes for better developer experience
- Update core schemas and route JSON schemas to accept any string value
- Add soft logging guidance for non-UUID tenantIds without blocking requests

**Why**
- Reduces friction for new users who want to use simple tenant identifiers like "demo-tenant" instead of generating UUIDs
- Aligns with common patterns where tenantId is often a human-readable string
- Maintains backward compatibility while improving DX

**Test Plan**
- `pnpm test --silent -t "Events API"` - All 12 tests pass including new non-UUID tenantId test
- Verified existing UUID tenantIds still work correctly
- Confirmed no breaking changes to API behavior

**Related Issues**
- closes #60