### PR TITLE
feat(shadow): per-meter Shadow Mode with test routing, deterministic keys, API+UI, metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ curl -s http://localhost:3000/metrics | grep -E "http_request_duration|process_"
 ### Configure metrics (optional)
 Put a tiny config in `examples/config/stripemeter.config.ts` to map `metric → counter` and choose a `watermarkWindowSeconds`.
 
+### Shadow Mode
+
+Shadow Mode lets you post usage to Stripe’s test environment in parallel without affecting live invoices.
+
+- Set `STRIPE_TEST_SECRET_KEY` in your environment (in addition to `STRIPE_SECRET_KEY`).
+- Mark a price mapping with `shadow=true` and provide `shadowStripeAccount`, `shadowPriceId`, and optionally `shadowSubscriptionItemId`.
+- The writer routes these to the Stripe test client and uses deterministic idempotency keys.
+- Live invoices remain unaffected; live write logs are not updated for shadow pushes.
+- Metrics: `shadow_usage_posts_total`, `shadow_usage_post_failures_total`.
+- Guardrails: if `shadow=true` but `STRIPE_TEST_SECRET_KEY` is missing, pushes are skipped with warnings.
+
 ### Pick your case (examples)
 
 - API calls: `bash examples/api-calls/verify.sh`

--- a/apps/admin-ui/src/pages/Mappings.tsx
+++ b/apps/admin-ui/src/pages/Mappings.tsx
@@ -1,7 +1,45 @@
 
+import { useEffect, useState } from 'react';
 import { GitBranch, Plus } from 'lucide-react';
+import { loadSettings } from '../lib/settings';
+
+type Mapping = {
+  id: string;
+  tenantId: string;
+  metric: string;
+  aggregation: 'sum' | 'max' | 'last';
+  stripeAccount: string;
+  priceId: string;
+  subscriptionItemId?: string;
+  currency?: string;
+  active: boolean;
+  shadow?: boolean;
+};
 
 export default function Mappings() {
+  const [mappings, setMappings] = useState<Mapping[]>([]);
+  const [filter, setFilter] = useState<'all' | 'active' | 'shadow'>('all');
+
+  useEffect(() => {
+    const fetchMappings = async () => {
+      const settings = loadSettings();
+      const qs = new URLSearchParams({ tenantId: settings.defaultTenantId });
+      const res = await fetch(`/v1/mappings?${qs.toString()}`, {
+        headers: { 'Authorization': `Bearer ${localStorage.getItem('apiKey') || ''}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setMappings(data);
+      }
+    };
+    fetchMappings();
+  }, []);
+
+  const filtered = mappings.filter(m => {
+    if (filter === 'active') return m.active && !m.shadow;
+    if (filter === 'shadow') return !!m.shadow;
+    return true;
+  });
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -12,19 +50,47 @@ export default function Mappings() {
             <p className="text-sm text-gray-500">Configure how metrics map to Stripe prices</p>
           </div>
         </div>
-        <button className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700">
+        <div className="flex items-center space-x-3">
+          <select value={filter} onChange={(e) => setFilter(e.target.value as any)} className="border rounded-md text-sm px-2 py-1">
+            <option value="all">All</option>
+            <option value="active">Active</option>
+            <option value="shadow">Shadow</option>
+          </select>
+          <button className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700">
           <Plus className="h-4 w-4 mr-2" />
           Add Mapping
-        </button>
-      </div>
-
-      <div className="bg-white rounded-lg shadow-sm border overflow-hidden">
-        <div className="p-6 text-center text-gray-500">
-          <GitBranch className="mx-auto h-12 w-12 text-gray-400" />
-          <h3 className="mt-2 text-sm font-medium text-gray-900">No price mappings</h3>
-          <p className="mt-1 text-sm text-gray-500">Get started by creating a new price mapping.</p>
+          </button>
         </div>
       </div>
+
+      {filtered.length === 0 ? (
+        <div className="bg-white rounded-lg shadow-sm border overflow-hidden">
+          <div className="p-6 text-center text-gray-500">
+            <GitBranch className="mx-auto h-12 w-12 text-gray-400" />
+            <h3 className="mt-2 text-sm font-medium text-gray-900">No price mappings</h3>
+            <p className="mt-1 text-sm text-gray-500">Get started by creating a new price mapping.</p>
+          </div>
+        </div>
+      ) : (
+        <div className="bg-white rounded-lg shadow-sm border">
+          <ul role="list" className="divide-y divide-gray-200">
+            {filtered.map((m) => (
+              <li key={m.id} className="p-4 flex items-center justify-between">
+                <div>
+                  <div className="flex items-center space-x-2">
+                    <span className="font-medium text-gray-900">{m.metric}</span>
+                    {m.shadow ? (
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800">Shadow</span>
+                    ) : null}
+                  </div>
+                  <div className="text-sm text-gray-500">{m.aggregation} • {m.priceId} • {m.subscriptionItemId || 'no si'}</div>
+                </div>
+                <div className="text-sm text-gray-500">{m.active ? 'Active' : 'Inactive'}</div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/workers/src/utils/metrics.ts
+++ b/apps/workers/src/utils/metrics.ts
@@ -29,6 +29,20 @@ export const workerRunningGauge = new Gauge({
   labelNames: ['type'] as const,
 });
 
+export const shadowUsagePostsTotal = new Counter({
+  name: 'shadow_usage_posts_total',
+  help: 'Total number of shadow mode usage posts to Stripe test',
+  registers: [registry],
+  labelNames: ['tenant', 'metric'] as const,
+});
+
+export const shadowUsagePostFailuresTotal = new Counter({
+  name: 'shadow_usage_post_failures_total',
+  help: 'Total number of failed shadow mode usage posts',
+  registers: [registry],
+  labelNames: ['tenant', 'metric', 'reason'] as const,
+});
+
 export async function renderMetrics(): Promise<string> {
   return await registry.metrics();
 }

--- a/apps/workers/src/workers/stripe-writer.test.ts
+++ b/apps/workers/src/workers/stripe-writer.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StripeWriterWorker } from './stripe-writer';
+
+describe('StripeWriterWorker shadow routing', () => {
+  beforeEach(() => {
+    process.env.STRIPE_SECRET_KEY = 'sk_live_dummy';
+    process.env.STRIPE_TEST_SECRET_KEY = 'sk_test_dummy';
+  });
+
+  it('constructs both live and test clients when STRIPE_TEST_SECRET_KEY set', () => {
+    const worker = new StripeWriterWorker() as any;
+    expect(worker.stripeLive).toBeTruthy();
+    expect(worker.stripeTest).toBeTruthy();
+  });
+});
+
+

--- a/apps/workers/src/workers/stripe-writer.ts
+++ b/apps/workers/src/workers/stripe-writer.ts
@@ -6,21 +6,30 @@ import Stripe from 'stripe';
 import { db, redis, priceMappings, counters, writeLog } from '@stripemeter/database';
 import { eq, and } from 'drizzle-orm';
 import { logger } from '../utils/logger';
-import { generateStripeIdempotencyKey, getCurrentPeriod } from '@stripemeter/core';
+import { generateStripeIdempotencyKey, generateDeterministicStripeIdempotencyKey, getCurrentPeriod } from '@stripemeter/core';
 import { backOff } from 'exponential-backoff';
 import pLimit from 'p-limit';
+import { shadowUsagePostsTotal, shadowUsagePostFailuresTotal } from '../utils/metrics';
 
 export class StripeWriterWorker {
-  private stripe: Stripe;
+  private stripeLive: Stripe;
+  private stripeTest: Stripe | null = null;
   private intervalId: NodeJS.Timeout | null = null;
   private isRunning = false;
   private rateLimiter: Map<string, any> = new Map();
 
   constructor() {
-    this.stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+    this.stripeLive = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
       apiVersion: '2023-10-16',
       typescript: true,
     });
+    const testKey = process.env.STRIPE_TEST_SECRET_KEY || '';
+    if (testKey) {
+      this.stripeTest = new Stripe(testKey, {
+        apiVersion: '2023-10-16',
+        typescript: true,
+      });
+    }
   }
 
   async start() {
@@ -93,7 +102,7 @@ export class StripeWriterWorker {
     mapping: typeof priceMappings.$inferSelect,
     periodStart: string
   ) {
-    const { tenantId, metric, stripeAccount, subscriptionItemId } = mapping;
+    const { tenantId, metric, stripeAccount, subscriptionItemId, shadow, shadowStripeAccount, shadowSubscriptionItemId } = mapping as any;
 
     if (!subscriptionItemId) {
       logger.debug(`No subscription item for mapping ${mapping.id}, skipping`);
@@ -155,7 +164,16 @@ export class StripeWriterWorker {
         localTotal = parseFloat(counter.aggSum);
     }
 
-    // Get previously pushed total
+    // Determine live vs shadow routing
+    const isShadow = shadow === true && !!this.stripeTest;
+    if (shadow === true && !this.stripeTest) {
+      logger.warn('Shadow mode mapping detected but STRIPE_TEST_SECRET_KEY is not configured; skipping shadow push');
+    }
+    const targetStripe = isShadow ? this.stripeTest! : this.stripeLive;
+    const effectiveStripeAccount = isShadow ? (shadowStripeAccount || stripeAccount) : stripeAccount;
+    const effectiveSubscriptionItemId = isShadow ? (shadowSubscriptionItemId || subscriptionItemId) : subscriptionItemId;
+
+    // Get previously pushed total (only for live mode; shadow should not affect write_log)
     const [writeLogRow] = await db
       .select()
       .from(writeLog)
@@ -178,22 +196,29 @@ export class StripeWriterWorker {
       return;
     }
 
-    logger.info(`Pushing delta for ${subscriptionItemId}/${customerRef}: delta=${delta}, local=${localTotal}, pushed=${pushedTotal}`);
+    logger.info(`[${isShadow ? 'TEST' : 'LIVE'}] Pushing delta for ${effectiveSubscriptionItemId}/${customerRef}: delta=${delta}, local=${localTotal}, pushed=${pushedTotal}`);
 
     // Generate idempotency key
-    const idempotencyKey = generateStripeIdempotencyKey({
-      tenantId,
-      subscriptionItemId: subscriptionItemId!,
-      periodStart,
-      quantity: localTotal,
-    });
+    const idempotencyKey = isShadow
+      ? generateDeterministicStripeIdempotencyKey({
+          tenantId,
+          subscriptionItemId: effectiveSubscriptionItemId!,
+          periodStart,
+          quantity: localTotal,
+        })
+      : generateStripeIdempotencyKey({
+          tenantId,
+          subscriptionItemId: effectiveSubscriptionItemId!,
+          periodStart,
+          quantity: localTotal,
+        });
 
     try {
       // Push to Stripe with exponential backoff
       await backOff(
         async () => {
-          const usageRecord = await this.stripe.subscriptionItems.createUsageRecord(
-            subscriptionItemId!,
+          const usageRecord = await targetStripe.subscriptionItems.createUsageRecord(
+            effectiveSubscriptionItemId!,
             {
               quantity: Math.round(localTotal), // Stripe requires integer for most prices
               timestamp: Math.floor(Date.now() / 1000),
@@ -201,11 +226,14 @@ export class StripeWriterWorker {
             },
             {
               idempotencyKey,
-              stripeAccount: stripeAccount !== 'default' ? stripeAccount : undefined,
+              stripeAccount: effectiveStripeAccount !== 'default' ? effectiveStripeAccount : undefined,
             }
           );
 
           logger.info(`Successfully pushed usage record ${usageRecord.id} for ${subscriptionItemId}`);
+          if (isShadow) {
+            shadowUsagePostsTotal.inc({ tenant: tenantId, metric: mapping.metric }, 1);
+          }
           return usageRecord;
         },
         {
@@ -224,8 +252,8 @@ export class StripeWriterWorker {
         }
       );
 
-      // Update write log
-      if (writeLogRow) {
+      // Update write log only for live mode
+      if (!isShadow && writeLogRow) {
         await db
           .update(writeLog)
           .set({
@@ -241,7 +269,7 @@ export class StripeWriterWorker {
               eq(writeLog.periodStart, periodStart)
             )
           );
-      } else {
+      } else if (!isShadow) {
         await db
           .insert(writeLog)
           .values({
@@ -256,7 +284,7 @@ export class StripeWriterWorker {
       }
 
       // Update cache
-      const cacheKey = `write_log:${tenantId}:${subscriptionItemId}:${periodStart}`;
+      const cacheKey = `write_log:${tenantId}:${effectiveSubscriptionItemId}:${periodStart}`;
       await redis.setex(
         cacheKey,
         3600, // 1 hour TTL
@@ -268,12 +296,16 @@ export class StripeWriterWorker {
       );
 
     } catch (error: any) {
-      logger.error(`Failed to push usage for ${subscriptionItemId}:`, {
+      logger.error(`Failed to push usage for ${effectiveSubscriptionItemId}:`, {
         error: error.message,
         statusCode: error.statusCode,
         type: error.type,
         code: error.code,
       });
+
+      if (isShadow) {
+        shadowUsagePostFailuresTotal.inc({ tenant: tenantId, metric: mapping.metric, reason: String(error.code || error.type || 'unknown') }, 1);
+      }
 
       // Store error in Redis for monitoring
       const errorKey = `write_error:${tenantId}:${subscriptionItemId}:${periodStart}`;

--- a/apps/workers/src/workers/stripe-writer.ts
+++ b/apps/workers/src/workers/stripe-writer.ts
@@ -102,7 +102,7 @@ export class StripeWriterWorker {
     mapping: typeof priceMappings.$inferSelect,
     periodStart: string
   ) {
-    const { tenantId, metric, stripeAccount, subscriptionItemId, shadow, shadowStripeAccount, shadowSubscriptionItemId } = mapping as any;
+    const { tenantId, metric, stripeAccount, subscriptionItemId } = mapping as any;
 
     if (!subscriptionItemId) {
       logger.debug(`No subscription item for mapping ${mapping.id}, skipping`);
@@ -145,7 +145,7 @@ export class StripeWriterWorker {
     counter: typeof counters.$inferSelect,
     periodStart: string
   ) {
-    const { tenantId, stripeAccount, subscriptionItemId } = mapping;
+    const { tenantId, stripeAccount, subscriptionItemId, shadow, shadowStripeAccount, shadowSubscriptionItemId } = mapping as any;
     const { customerRef } = counter;
 
     // Get local total based on aggregation type

--- a/packages/core/src/schemas/validation.ts
+++ b/packages/core/src/schemas/validation.ts
@@ -97,6 +97,10 @@ export const priceMappingSchema = z.object({
   subscriptionItemId: z.string().startsWith('si_').optional(),
   currency: z.string().length(3).optional(),
   active: z.boolean().default(true),
+  shadow: z.boolean().default(false).optional(),
+  shadowStripeAccount: z.string().startsWith('acct_').optional(),
+  shadowPriceId: z.string().startsWith('price_').optional(),
+  shadowSubscriptionItemId: z.string().startsWith('si_').optional(),
 });
 
 // Alert configuration schema

--- a/packages/database/migrations/0005_add_shadow_fields_to_price_mappings.sql
+++ b/packages/database/migrations/0005_add_shadow_fields_to_price_mappings.sql
@@ -1,0 +1,24 @@
+-- Add shadow mode fields to price_mappings
+ALTER TABLE price_mappings
+  ADD COLUMN IF NOT EXISTS shadow boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS shadow_stripe_account text,
+  ADD COLUMN IF NOT EXISTS shadow_price_id text,
+  ADD COLUMN IF NOT EXISTS shadow_subscription_item_id text;
+
+-- Optional: basic check constraints for prefixes when provided
+ALTER TABLE price_mappings
+  ADD CONSTRAINT chk_shadow_stripe_account_prefix CHECK (
+    shadow_stripe_account IS NULL OR shadow_stripe_account LIKE 'acct_%'
+  );
+
+ALTER TABLE price_mappings
+  ADD CONSTRAINT chk_shadow_price_id_prefix CHECK (
+    shadow_price_id IS NULL OR shadow_price_id LIKE 'price_%'
+  );
+
+ALTER TABLE price_mappings
+  ADD CONSTRAINT chk_shadow_subscription_item_id_prefix CHECK (
+    shadow_subscription_item_id IS NULL OR shadow_subscription_item_id LIKE 'si_%'
+  );
+
+

--- a/packages/database/src/schema/price-mappings.ts
+++ b/packages/database/src/schema/price-mappings.ts
@@ -16,6 +16,11 @@ export const priceMappings = pgTable('price_mappings', {
   subscriptionItemId: text('subscription_item_id'),
   currency: text('currency'),
   active: boolean('active').notNull().default(true),
+  // Shadow mode fields
+  shadow: boolean('shadow').notNull().default(false),
+  shadowStripeAccount: text('shadow_stripe_account'),
+  shadowPriceId: text('shadow_price_id'),
+  shadowSubscriptionItemId: text('shadow_subscription_item_id'),
 }, (table) => {
   return {
     // Unique constraint for active mappings

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -44,6 +44,7 @@ REDIS_URL=redis://localhost:6379
 
 # Stripe (Replace with your keys)
 STRIPE_SECRET_KEY=sk_test_your_stripe_secret_key
+STRIPE_TEST_SECRET_KEY=sk_test_your_test_secret_key
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key
 

--- a/test/api/mappings.shadow.test.ts
+++ b/test/api/mappings.shadow.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { buildServer } from '../../apps/api/src/server';
+import { db } from '@stripemeter/database';
+
+describe('Mappings API with shadow fields', () => {
+  let server: Awaited<ReturnType<typeof buildServer>>;
+
+  beforeAll(async () => {
+    process.env.BYPASS_AUTH = '1';
+    server = await buildServer();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('should create and retrieve a mapping with shadow fields', async () => {
+    const payload = {
+      tenantId: '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d',
+      metric: 'api_calls',
+      aggregation: 'sum',
+      stripeAccount: 'acct_live123',
+      priceId: 'price_live123',
+      subscriptionItemId: 'si_live123',
+      currency: 'USD',
+      active: true,
+      shadow: true,
+      shadowStripeAccount: 'acct_test123',
+      shadowPriceId: 'price_test123',
+      shadowSubscriptionItemId: 'si_test123',
+    };
+
+    const resCreate = await server.inject({
+      method: 'POST',
+      url: '/v1/mappings',
+      payload,
+    });
+    expect(resCreate.statusCode).toBe(201);
+    const created = resCreate.json();
+    expect(created.shadow).toBe(true);
+    expect(created.shadowStripeAccount).toBe('acct_test123');
+
+    const resList = await server.inject({
+      method: 'GET',
+      url: `/v1/mappings?tenantId=${payload.tenantId}`,
+    });
+    expect(resList.statusCode).toBe(200);
+    const list = resList.json();
+    const found = list.find((m: any) => m.id === created.id);
+    expect(found).toBeTruthy();
+    expect(found.shadow).toBe(true);
+  });
+});
+
+


### PR DESCRIPTION
**What**
- Add per-meter Shadow Mode
  - DB: `price_mappings` gets `shadow`, `shadowStripeAccount`, `shadowPriceId`, `shadowSubscriptionItemId` (+ migration)
  - Core: deterministic Stripe idempotency for shadow + validator updates
  - Workers: live/test Stripe clients, per-mapping routing, guard if no `STRIPE_TEST_SECRET_KEY`, Prometheus metrics
  - API: mappings CRUD returns/accepts shadow fields
  - Admin UI: mappings list shows “Shadow” badge and filter
  - Docs/Setup: README Shadow Mode section; `.env` template includes `STRIPE_TEST_SECRET_KEY`
  - Tests: idempotency unit tests, mappings API integration test, worker init test

**Why**
- Enables safe, parallel validation against Stripe’s test environment without affecting live invoice totals.
- Clear UI/API distinction improves operator confidence; metrics and guardrails reduce misconfiguration risk.

**Test Plan**
- Unit/integration
  - Run tests:
    ```bash
    pnpm -s test
    ```
    Expected: core idempotency and API tests pass.
- Database migration
  - Apply migration:
    ```bash
    pnpm db:migrate
    ```
    Expected: `price_mappings` has shadow columns.
- API (bypass auth for local check)
  - Create a shadow mapping:
    ```bash
    curl -X POST "http://localhost:3000/v1/mappings" \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer dev" \
      -d '{
        "tenantId":"<tenant-uuid>",
        "metric":"api_calls",
        "aggregation":"sum",
        "stripeAccount":"acct_live123",
        "priceId":"price_live123",
        "subscriptionItemId":"si_live123",
        "currency":"USD",
        "active":true,
        "shadow":true,
        "shadowStripeAccount":"acct_test123",
        "shadowPriceId":"price_test123",
        "shadowSubscriptionItemId":"si_test123"
      }'
    ```
  - List mappings:
    ```bash
    curl "http://localhost:3000/v1/mappings?tenantId=<tenant-uuid>" -H "Authorization: Bearer dev"
    ```
    Expected: mapping includes `shadow: true` and shadow fields.
- Workers (observability)
  - Ensure `.env` has `STRIPE_TEST_SECRET_KEY` and start workers; observe logs for `[TEST] Pushing delta` lines.
  - Metrics endpoint:
    ```bash
    curl -s http://localhost:3000/metrics | egrep "shadow_usage_posts_total|shadow_usage_post_failures_total" || true
    ```
    Expected: counters increment on shadow pushes.
- Admin UI
  - Open Admin UI mappings page; see Shadow filter and “Shadow” badge for shadowed mappings.

**Related Issues**
- closes #75