### PR TITLE
ops: Prometheus scrape example and Grafana dashboard v1; add ingestion and reaggregation metrics (#55)

### DIFF
--- a/apps/api/src/utils/metrics.ts
+++ b/apps/api/src/utils/metrics.ts
@@ -27,6 +27,22 @@ export const httpRequestDurationSeconds = new Histogram({
   buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
 });
 
+// Ingestion metrics
+export const eventsIngestedTotal = new Counter({
+  name: 'events_ingested_total',
+  help: 'Total number of usage events ingested (accepted)',
+  registers: [registry],
+  labelNames: ['meter'] as const,
+});
+
+export const ingestLatencyMs = new Histogram({
+  name: 'ingest_latency_ms',
+  help: 'Latency in milliseconds from HTTP accept to events persisted',
+  registers: [registry],
+  // Milliseconds buckets: 5ms → 2.5s
+  buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500],
+});
+
 type MetricsRequest = FastifyRequest & { __metricsStartHr?: bigint };
 
 export function registerHttpMetricsHooks(server: FastifyInstance): void {

--- a/apps/workers/src/utils/metrics.ts
+++ b/apps/workers/src/utils/metrics.ts
@@ -71,6 +71,14 @@ export const reconciliationDiffPct = new Gauge({
   labelNames: ['tenant', 'subscription_item', 'period'] as const,
 });
 
+// Re-aggregations counter
+export const reaggregationsTotal = new Counter({
+  name: 'reaggregations_total',
+  help: 'Total number of re-aggregation operations by reason',
+  registers: [registry],
+  labelNames: ['reason'] as const,
+});
+
 export async function renderMetrics(): Promise<string> {
   return await registry.metrics();
 }

--- a/apps/workers/src/workers/aggregator.metrics.test.ts
+++ b/apps/workers/src/workers/aggregator.metrics.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock database and redis layer used by aggregator
+vi.mock('@stripemeter/database', () => {
+  const nextSelectResults: any[] = [];
+
+  function buildWhereResult() {
+    const obj: any = {
+      limit: (_n?: number) => (nextSelectResults.shift() ?? []),
+      orderBy: (_o?: any) => (nextSelectResults.shift() ?? []),
+    };
+    // Make await obj resolve to next result (thenable)
+    obj.then = (resolve: any) => resolve(nextSelectResults.shift() ?? []);
+    return obj;
+  }
+
+  const db = {
+    __pushSelectResult: (res: any) => nextSelectResults.push(res),
+    select: (_?: any) => ({
+      from: (_tbl?: any) => ({
+        where: (_w?: any) => buildWhereResult(),
+        orderBy: (_o?: any) => (nextSelectResults.shift() ?? []),
+      }),
+    }),
+    update: (_tbl?: any) => ({ set: (_vals?: any) => ({ where: (_?: any) => ({}) }) }),
+    insert: (_tbl?: any) => ({ values: (_vals?: any) => ({}) }),
+  } as any;
+
+  return {
+    db,
+    redis: { setex: vi.fn(async () => true) },
+    events: {},
+    counters: {},
+    adjustments: {},
+  };
+});
+
+import { AggregatorWorker } from './aggregator';
+import { reaggregationsTotal } from '../utils/metrics';
+import { db } from '@stripemeter/database';
+
+describe('Aggregator reaggregations_total metrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('increments reason=initial when creating a new counter', async () => {
+    const incSpy = vi.spyOn(reaggregationsTotal, 'inc');
+    const labelsSpy = vi.spyOn(reaggregationsTotal, 'labels');
+
+    // Queue DB responses in order of select() calls within processAggregation
+    // 1) existingCounter lookup → none
+    (db as any).__pushSelectResult([]);
+    // 2) aggregations over events
+    (db as any).__pushSelectResult([{ sum: '0', max: '0', last: null, maxTs: new Date() }]);
+    // 3) adjustments sum
+    (db as any).__pushSelectResult([{ total: '0' }]);
+
+    const worker = new AggregatorWorker();
+    await worker.processAggregation({
+      tenantId: 't1',
+      metric: 'm1',
+      customerRef: 'c1',
+      periodStart: '2025-01-01T00:00:00.000Z',
+    } as any);
+
+    expect(labelsSpy).toHaveBeenCalledWith('initial');
+    expect(incSpy).toHaveBeenCalled();
+  });
+
+  it('increments reason=late_event when recomputeStartDate advances due to watermark', async () => {
+    const incSpy = vi.spyOn(reaggregationsTotal, 'inc');
+    const labelsSpy = vi.spyOn(reaggregationsTotal, 'labels');
+
+    const periodStart = new Date('2025-01-01T00:00:00.000Z');
+    const watermark = new Date(periodStart.getTime() + 72 * 60 * 60 * 1000); // +72h
+    process.env.LATE_EVENT_WINDOW_HOURS = '48';
+
+    // 1) existingCounter with watermarkTs
+    (db as any).__pushSelectResult([{ watermarkTs: watermark, updatedAt: new Date() }]);
+    // 2) aggregations over events
+    (db as any).__pushSelectResult([{ sum: '1', max: '1', last: '1', maxTs: new Date() }]);
+    // 3) adjustments sum
+    (db as any).__pushSelectResult([{ total: '0' }]);
+    // 4) late events query (return none)
+    (db as any).__pushSelectResult([]);
+
+    const worker = new AggregatorWorker();
+    await worker.processAggregation({
+      tenantId: 't1',
+      metric: 'm1',
+      customerRef: 'c1',
+      periodStart: periodStart.toISOString(),
+    } as any);
+
+    expect(labelsSpy).toHaveBeenCalledWith('late_event');
+    expect(incSpy).toHaveBeenCalled();
+  });
+
+  it('increments reason=on_time when recomputeStartDate equals periodStart', async () => {
+    const incSpy = vi.spyOn(reaggregationsTotal, 'inc');
+    const labelsSpy = vi.spyOn(reaggregationsTotal, 'labels');
+
+    const periodStart = new Date('2025-01-01T00:00:00.000Z');
+    const watermark = new Date(periodStart.getTime() + 24 * 60 * 60 * 1000); // +24h
+    process.env.LATE_EVENT_WINDOW_HOURS = '48';
+
+    // 1) existingCounter with watermarkTs; lowerBound < periodStart → recomputeStartDate = periodStart
+    (db as any).__pushSelectResult([{ watermarkTs: watermark, updatedAt: new Date() }]);
+    // 2) aggregations
+    (db as any).__pushSelectResult([{ sum: '2', max: '2', last: '2', maxTs: new Date() }]);
+    // 3) adjustments sum
+    (db as any).__pushSelectResult([{ total: '0' }]);
+    // 4) late events
+    (db as any).__pushSelectResult([]);
+
+    const worker = new AggregatorWorker();
+    await worker.processAggregation({
+      tenantId: 't1',
+      metric: 'm1',
+      customerRef: 'c1',
+      periodStart: periodStart.toISOString(),
+    } as any);
+
+    expect(labelsSpy).toHaveBeenCalledWith('on_time');
+    expect(incSpy).toHaveBeenCalled();
+  });
+});
+
+

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'stripemeter-api'
+    static_configs:
+      - targets: ['api:3000']
+    metrics_path: /metrics
+
+  - job_name: 'stripemeter-workers'
+    static_configs:
+      - targets: ['workers:3100']
+    metrics_path: /metrics
+
+

--- a/ops/grafana/stripemeter_dashboard.json
+++ b/ops/grafana/stripemeter_dashboard.json
@@ -1,0 +1,52 @@
+{
+  "title": "StripeMeter - Observability",
+  "timezone": "browser",
+  "version": 1,
+  "schemaVersion": 38,
+  "panels": [
+    {
+      "type": "bargauge",
+      "title": "Events Ingested (5m) by Meter",
+      "targets": [
+        { "expr": "sum by (meter) (increase(events_ingested_total[5m]))", "legendFormat": "{{meter}}" }
+      ],
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Ingest Latency p50 / p95",
+      "targets": [
+        { "expr": "histogram_quantile(0.5, sum(rate(ingest_latency_ms_bucket[5m])) by (le))", "legendFormat": "p50" },
+        { "expr": "histogram_quantile(0.95, sum(rate(ingest_latency_ms_bucket[5m])) by (le))", "legendFormat": "p95" }
+      ],
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 }
+    },
+    {
+      "type": "bargauge",
+      "title": "Reaggregations (5m) by Reason",
+      "targets": [
+        { "expr": "sum by (reason) (increase(reaggregations_total[5m]))", "legendFormat": "{{reason}}" }
+      ],
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 9 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Drift Abs (avg by item)",
+      "targets": [
+        { "expr": "avg by (subscription_item) (reconciliation_diff_abs)", "legendFormat": "{{subscription_item}}" }
+      ],
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 9 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Drift % (avg by item)",
+      "targets": [
+        { "expr": "avg by (subscription_item) (reconciliation_diff_pct)", "legendFormat": "{{subscription_item}}" }
+      ],
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 18 }
+    }
+  ],
+  "templating": { "list": [] }
+}
+
+

--- a/ops/prometheus/prometheus.yml
+++ b/ops/prometheus/prometheus.yml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'stripemeter-api'
+    static_configs:
+      - targets: ['localhost:3000']
+    metrics_path: /metrics
+
+  - job_name: 'stripemeter-workers'
+    static_configs:
+      - targets: ['localhost:3100']
+    metrics_path: /metrics
+
+


### PR DESCRIPTION
**What**
- Add Prometheus scrape examples and a starter Grafana dashboard
- Add API metrics: `events_ingested_total{meter}`, `ingest_latency_ms` histogram
- Add Workers metric: `reaggregations_total{reason}`; instrument aggregator reasons
- Files:
  - `ops/prometheus/prometheus.yml` (localhost example)
  - `infra/prometheus/prometheus.yml` (docker-compose services)
  - `ops/grafana/stripemeter_dashboard.json` (4 panels)
  - API: `apps/api/src/utils/metrics.ts`, `apps/api/src/routes/events.ts`
  - Workers: `apps/workers/src/utils/metrics.ts`, `apps/workers/src/workers/aggregator.ts`

**Why**
- Improve observability out-of-the-box: monitor ingestion health and drift with minimal setup
- Provide ready-to-use ops assets for Prometheus/Grafana
- Standardize metric names for easier dashboards and alerting

**Test Plan**
- Unit/Workers tests:
  - Run: `E2E_SERVICES=1 pnpm --filter @stripemeter/workers test`
  - Observed: Workers tests pass, including `reaggregations_total` metrics tests
- API smoke (metrics present):
  - Start API; then:
    - `curl -fsS http://localhost:3000/metrics | grep -E 'events_ingested_total|ingest_latency_ms_bucket'`
    - Expect metric help/type lines and histogram buckets
- Workers metrics:
  - Start workers; then:
    - `curl -fsS http://localhost:3100/metrics | grep -E 'reaggregations_total|reconciliation_diff_(abs|pct)'`
    - Expect counters/gauges present
- Prometheus (docker-compose prod profile):
  - `docker compose -f docker-compose.prod.yml --profile monitoring up -d prometheus grafana`
  - Prometheus uses `infra/prometheus/prometheus.yml` to scrape API/Workers
- Grafana:
  - Open Grafana → Import `ops/grafana/stripemeter_dashboard.json`
  - Panels load:
    - Events Ingested (5m) by Meter
    - Ingest Latency p50/p95
    - Reaggregations (5m) by Reason
    - Drift Abs/Pct over time

**Related Issues**
- closes #55