### PR TITLE
Feature/api auth scopes

### DIFF
--- a/apps/api/src/constants/scopes.ts
+++ b/apps/api/src/constants/scopes.ts
@@ -1,0 +1,16 @@
+export const SCOPES = Object.freeze({
+  PROJECT_READ: 'project:read',
+  PROJECT_WRITE: 'project:write',
+  EVENTS_READ: 'events:read',
+  EVENTS_WRITE: 'events:write',
+  USAGE_READ: 'usage:read',
+  USAGE_WRITE: 'usage:write',
+  MAPPINGS_READ: 'mappings:read',
+  MAPPINGS_WRITE: 'mappings:write',
+  RECONCILIATION_READ: 'reconciliation:read',
+  RECONCILIATION_WRITE: 'reconciliation:write',
+  ALERTS_READ: 'alerts:read',
+  ALERTS_WRITE: 'alerts:write',
+  SIMULATION_READ: 'simulation:read',
+  SIMULATION_WRITE: 'simulation:write',
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -3,41 +3,50 @@ import { db } from '@stripemeter/database';
 import { apiKeys } from '@stripemeter/database';
 import { eq } from 'drizzle-orm';
 import { createHmac, randomBytes } from 'crypto';
+import { requireScopes } from '../utils/auth';
+import { SCOPES } from '../constants/scopes';
 
 export async function adminRoutes(server: FastifyInstance) {
-  server.post('/api-keys', async (request, reply) => {
-    const body = request.body as any;
-    const organisationId = request.tenant?.organisationId || (process.env.BYPASS_AUTH === '1' ? '00000000-0000-0000-0000-000000000000' : undefined);
-    if (!organisationId) return reply.status(401).send({ error: 'unauthenticated' });
-    const name = body?.name || 'New API Key';
-    const projectId = body?.projectId as string | undefined;
-    const scopes = Array.isArray(body?.scopes) ? body.scopes.join(',') : 'project:read,project:write';
+  server.post(
+    '/api-keys',
+    { preHandler: requireScopes(SCOPES.PROJECT_WRITE) },
+    async (request, reply) => {
+      const body = request.body as any;
+      const organisationId = request.tenant?.organisationId || (process.env.BYPASS_AUTH === '1' ? '00000000-0000-0000-0000-000000000000' : undefined);
+      if (!organisationId) return reply.status(401).send({ error: 'unauthenticated' });
+      const name = body?.name || 'New API Key';
+      const projectId = body?.projectId as string | undefined;
+      const scopes = Array.isArray(body?.scopes) ? body.scopes.join(',') : 'project:read,project:write';
 
-    const { apiKey, prefix, last4, secretHash } = generateApiKeyHash('sm');
-    const inserted = await db.insert(apiKeys).values({ organisationId, projectId, name, prefix, lastFour: last4, secretHash, scopes }).returning();
-    return reply.status(201).send({ apiKey, key: inserted[0] });
-  });
+      const { apiKey, prefix, last4, secretHash } = generateApiKeyHash('sm');
+      const inserted = await db.insert(apiKeys).values({ organisationId, projectId, name, prefix, lastFour: last4, secretHash, scopes }).returning();
+      return reply.status(201).send({ apiKey, key: inserted[0] });
+    });
 
-  server.post('/api-keys/:id/rotate', async (request, reply) => {
-    const organisationId = request.tenant?.organisationId || (process.env.BYPASS_AUTH === '1' ? '00000000-0000-0000-0000-000000000000' : undefined);
-    if (!organisationId) return reply.status(401).send({ error: 'unauthenticated' });
-    const id = (request.params as any).id as string;
-    const { apiKey, prefix, last4, secretHash } = generateApiKeyHash('sm');
-    const updated = await db.update(apiKeys)
-      .set({ prefix, lastFour: last4, secretHash })
-      .where(eq(apiKeys.id, id))
-      .returning();
-    return reply.status(200).send({ apiKey, key: updated[0] });
-  });
+  server.post('/api-keys/:id/rotate',
+    { preHandler: requireScopes(SCOPES.PROJECT_WRITE) },
+    async (request, reply) => {
+      const organisationId = request.tenant?.organisationId || (process.env.BYPASS_AUTH === '1' ? '00000000-0000-0000-0000-000000000000' : undefined);
+      if (!organisationId) return reply.status(401).send({ error: 'unauthenticated' });
+      const id = (request.params as any).id as string;
+      const { apiKey, prefix, last4, secretHash } = generateApiKeyHash('sm');
+      const updated = await db.update(apiKeys)
+        .set({ prefix, lastFour: last4, secretHash })
+        .where(eq(apiKeys.id, id))
+        .returning();
+      return reply.status(200).send({ apiKey, key: updated[0] });
+    });
 
-  server.post('/api-keys/:id/revoke', async (request, reply) => {
-    const id = (request.params as any).id as string;
-    const updated = await db.update(apiKeys)
-      .set({ active: false, revokedAt: new Date() })
-      .where(eq(apiKeys.id, id))
-      .returning();
-    return reply.status(200).send({ key: updated[0] });
-  });
+  server.post('/api-keys/:id/revoke',
+    { preHandler: requireScopes(SCOPES.PROJECT_WRITE) },
+    async (request, reply) => {
+      const id = (request.params as any).id as string;
+      const updated = await db.update(apiKeys)
+        .set({ active: false, revokedAt: new Date() })
+        .where(eq(apiKeys.id, id))
+        .returning();
+      return reply.status(200).send({ key: updated[0] });
+    });
 }
 
 function generateApiKeyHash(prefixBase: string) {

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -4,6 +4,8 @@
 
 import { FastifyPluginAsync } from 'fastify';
 import type { AlertConfig } from '@stripemeter/core';
+import { requireScopes } from '../utils/auth';
+import { SCOPES } from '../constants/scopes';
 
 export const alertsRoutes: FastifyPluginAsync = async (server) => {
   /**
@@ -50,6 +52,7 @@ export const alertsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.ALERTS_READ),
   }, async (_request, reply) => {
     // TODO: Implement alert retrieval from database
     reply.send([]);
@@ -97,6 +100,7 @@ export const alertsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.ALERTS_WRITE),
   }, async (request, reply) => {
     // TODO: Implement alert creation
     const alertConfig: AlertConfig = {
@@ -135,6 +139,7 @@ export const alertsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.ALERTS_WRITE),
   }, async (_request, reply) => {
     // TODO: Implement alert update
     reply.status(501).send({ 
@@ -166,6 +171,7 @@ export const alertsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.ALERTS_WRITE),
   }, async (_request, reply) => {
     // TODO: Implement alert deletion
     reply.status(204).send();
@@ -221,6 +227,7 @@ export const alertsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.ALERTS_READ),
   }, async (_request, reply) => {
     // TODO: Implement alert history retrieval
     reply.send([]);

--- a/apps/api/src/routes/events.ts
+++ b/apps/api/src/routes/events.ts
@@ -17,8 +17,9 @@ import {
 import { Queue } from 'bullmq';
 import { warnIfNonUuidTenantId } from '../utils/logger';
 import { eventsIngestedTotal, ingestLatencyMs } from '../utils/metrics';
-import { requireScopes } from '../utils/auth';
+import { requireScopes, verifyTenantId } from '../utils/auth';
 import { SCOPES } from '../constants/scopes';
+import { request } from 'http';
 
 export const eventsRoutes: FastifyPluginAsync = async (server) => {
   // Lazily import database to play well with test mocks
@@ -121,7 +122,10 @@ export const eventsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
-    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.EVENTS_WRITE),
+    preHandler: [
+      requireScopes(SCOPES.PROJECT_WRITE, SCOPES.EVENTS_WRITE),
+      verifyTenantId('events'),
+    ],
   }, async (request, reply) => {
     const ingestStart = process.hrtime.bigint();
     // Validate request body

--- a/apps/api/src/routes/events.ts
+++ b/apps/api/src/routes/events.ts
@@ -17,6 +17,8 @@ import {
 import { Queue } from 'bullmq';
 import { warnIfNonUuidTenantId } from '../utils/logger';
 import { eventsIngestedTotal, ingestLatencyMs } from '../utils/metrics';
+import { requireScopes } from '../utils/auth';
+import { SCOPES } from '../constants/scopes';
 
 export const eventsRoutes: FastifyPluginAsync = async (server) => {
   // Lazily import database to play well with test mocks
@@ -119,6 +121,7 @@ export const eventsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.EVENTS_WRITE),
   }, async (request, reply) => {
     const ingestStart = process.hrtime.bigint();
     // Validate request body
@@ -317,6 +320,7 @@ export const eventsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.EVENTS_WRITE),
   }, async (request, reply) => {
     // Validate request body
     const validationResult = backfillRequestSchema.safeParse(request.body);
@@ -472,12 +476,13 @@ export const eventsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.EVENTS_READ),
   }, async (request, reply) => {
     const { operationId } = request.params;
 
     try {
       const operation = await backfillRepo.getById(operationId);
-      
+
       if (!operation) {
         return reply.status(404).send({
           error: 'Not Found',
@@ -556,6 +561,7 @@ export const eventsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.EVENTS_READ),
   }, async (request, reply) => {
     try {
       const operations = await backfillRepo.list({
@@ -631,7 +637,7 @@ export const eventsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
-
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.EVENTS_READ),
   }, async (_request, reply) => {
     const validationResult = getEventsQuerySchema.safeParse(_request.query);
     if (!validationResult.success) {

--- a/apps/api/src/routes/events.ts
+++ b/apps/api/src/routes/events.ts
@@ -19,7 +19,6 @@ import { warnIfNonUuidTenantId } from '../utils/logger';
 import { eventsIngestedTotal, ingestLatencyMs } from '../utils/metrics';
 import { requireScopes, verifyTenantId } from '../utils/auth';
 import { SCOPES } from '../constants/scopes';
-import { request } from 'http';
 
 export const eventsRoutes: FastifyPluginAsync = async (server) => {
   // Lazily import database to play well with test mocks
@@ -79,6 +78,26 @@ export const eventsRoutes: FastifyPluginAsync = async (server) => {
     schema: {
       description: 'Ingest a batch of usage events',
       tags: ['events'],
+      body: {
+        type: 'object',
+        required: ['events'],
+        properties: {
+          events: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                metric: { type: 'string' },
+                tenantId: { type: 'string' },
+                customerRef: { type: 'string' },
+                quantity: { type: 'number' },
+                ts: { type: 'string', format: 'date-time' },
+                source: { type: 'string' },
+              },
+            }
+          },
+        },
+      },
       headers: {
         type: 'object',
         properties: {
@@ -118,6 +137,24 @@ export const eventsRoutes: FastifyPluginAsync = async (server) => {
                 },
               },
             },
+          },
+        },
+        401: {
+          type: 'object',
+          properties: {
+            error: { type: 'string' },
+          },
+          example: {
+            error: 'Missing API Key',
+          },
+        },
+        403: {
+          type: 'object',
+          properties: {
+            error: { type: 'string' },
+          },
+          example: {
+            error: 'Mismatched tenantId in events',
           },
         },
       },

--- a/apps/api/src/routes/mappings.ts
+++ b/apps/api/src/routes/mappings.ts
@@ -6,6 +6,8 @@ import { FastifyPluginAsync } from 'fastify';
 import type { PriceMapping } from '@stripemeter/core';
 import { db, priceMappings } from '@stripemeter/database';
 import { eq, and } from 'drizzle-orm';
+import { requireScopes } from '../utils/auth';
+import { SCOPES } from '../constants/scopes';
 
 export const mappingsRoutes: FastifyPluginAsync = async (server) => {
   /**
@@ -49,6 +51,7 @@ export const mappingsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.MAPPINGS_READ),
   }, async (request, reply) => {
     const { tenantId, active } = request.query;
     const whereClauses: any[] = [eq(priceMappings.tenantId, tenantId as any)];
@@ -100,6 +103,7 @@ export const mappingsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.MAPPINGS_WRITE),
   }, async (request, reply) => {
     const body = request.body as any;
     const [row] = await db.insert(priceMappings).values(body).returning();
@@ -137,6 +141,7 @@ export const mappingsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.MAPPINGS_WRITE),
   }, async (request, reply) => {
     const { id } = request.params;
     const updates = request.body as any;
@@ -167,6 +172,7 @@ export const mappingsRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.MAPPINGS_WRITE),
   }, async (request, reply) => {
     const { id } = request.params;
     await db.delete(priceMappings).where(eq(priceMappings.id, id as any));

--- a/apps/api/src/routes/reconciliation.ts
+++ b/apps/api/src/routes/reconciliation.ts
@@ -7,6 +7,8 @@ import type { ReconciliationSummaryResponse } from '@stripemeter/core';
 import { db, priceMappings, reconciliationReports } from '@stripemeter/database';
 import { and, eq, gte, lte, sql } from 'drizzle-orm';
 import http from 'http';
+import { requireScopes } from '../utils/auth';
+import { SCOPES } from '../constants/scopes';
 
 export const reconciliationRoutes: FastifyPluginAsync = async (server) => {
   /**
@@ -89,6 +91,7 @@ export const reconciliationRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.RECONCILIATION_READ),
   }, async (request, reply) => {
     const { period } = request.params;
     const { tenantId, format } = request.query as any;
@@ -195,6 +198,7 @@ export const reconciliationRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.RECONCILIATION_WRITE),
   }, async (_request, reply) => {
     try {
       const port = Number(process.env.WORKER_HTTP_PORT || 3100);
@@ -421,6 +425,7 @@ export const reconciliationRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.RECONCILIATION_READ),
   }, async (_request, reply) => {
     // TODO: Apply adjustments
     reply.send({

--- a/apps/api/src/routes/simulations.ts
+++ b/apps/api/src/routes/simulations.ts
@@ -9,6 +9,8 @@ import { InvoiceSimulator } from '@stripemeter/pricing-lib';
 import { Queue } from 'bullmq';
 import { redis } from '@stripemeter/database';
 import { z } from 'zod';
+import { requireScopes } from '../utils/auth';
+import { SCOPES } from '../constants/scopes';
 
 // Request/Response schemas
 const CreateScenarioSchema = z.object({
@@ -116,6 +118,7 @@ export const simulationRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.SIMULATION_READ),
   }, async (request, reply) => {
     const tenantId = getTenantId(request);
     const { active, tag, limit = 20, offset = 0, sortBy = 'createdAt', sortOrder = 'desc' } = request.query as any;
@@ -201,6 +204,7 @@ export const simulationRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.SIMULATION_READ),
   }, async (request, reply) => {
     const tenantId = getTenantId(request);
     const { id } = request.params;
@@ -244,6 +248,7 @@ export const simulationRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.SIMULATION_WRITE),
   }, async (request, reply) => {
     const tenantId = getTenantId(request);
     const validationResult = CreateScenarioSchema.safeParse(request.body);
@@ -318,6 +323,7 @@ export const simulationRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.SIMULATION_WRITE),
   }, async (request, reply) => {
     const tenantId = getTenantId(request);
     const { id } = request.params;
@@ -390,6 +396,7 @@ export const simulationRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.SIMULATION_WRITE),
   }, async (request, reply) => {
     const tenantId = getTenantId(request);
     const { id } = request.params;
@@ -431,6 +438,7 @@ export const simulationRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.SIMULATION_WRITE),
   }, async (request, reply) => {
     const tenantId = getTenantId(request);
     const validationResult = RunScenarioSchema.safeParse(request.body);
@@ -528,6 +536,7 @@ export const simulationRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.SIMULATION_READ),
   }, async (request, reply) => {
     const tenantId = getTenantId(request);
     const { id } = request.params;
@@ -580,6 +589,7 @@ export const simulationRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.SIMULATION_READ),
   }, async (request, reply) => {
     const tenantId = getTenantId(request);
     const { scenarioId, status, runType, limit = 20, offset = 0 } = request.query as any;
@@ -642,6 +652,7 @@ export const simulationRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.SIMULATION_WRITE),
   }, async (request, reply) => {
     const tenantId = getTenantId(request);
     const validationResult = BatchRunSchema.safeParse(request.body);
@@ -767,6 +778,7 @@ export const simulationRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.SIMULATION_READ),
   }, async (request, reply) => {
     const tenantId = getTenantId(request);
     const { id } = request.params;

--- a/apps/api/src/routes/usage.ts
+++ b/apps/api/src/routes/usage.ts
@@ -9,6 +9,8 @@ import { db, counters, priceMappings, redis, events } from '@stripemeter/databas
 import { InvoiceSimulator, type UsageLineItem, type PriceConfig } from '@stripemeter/pricing-lib';
 import { and, eq, gte, lte, sql } from 'drizzle-orm';
 import { GetUsageHistoryQueryInput } from '@stripemeter/core';
+import { requireScopes } from '../utils/auth';
+import { SCOPES } from '../constants/scopes';
 
 export const usageRoutes: FastifyPluginAsync = async (server) => {
   /**
@@ -72,6 +74,7 @@ export const usageRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.USAGE_READ),
   }, async (request, reply) => {
     const { tenantId, customerRef } = request.query;
 
@@ -179,6 +182,7 @@ export const usageRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_WRITE, SCOPES.USAGE_WRITE),
   }, async (request, reply) => {
     const { tenantId, customerRef, periodStart, periodEnd } = request.body;
 
@@ -322,6 +326,7 @@ export const usageRoutes: FastifyPluginAsync = async (server) => {
         },
       },
     },
+    preHandler: requireScopes(SCOPES.PROJECT_READ, SCOPES.USAGE_READ),
   }, async (request, reply) => {
     const validationResult = getUsageHistoryQuerySchema.safeParse(request.query);
     if (!validationResult.success) {
@@ -417,7 +422,7 @@ export const usageRoutes: FastifyPluginAsync = async (server) => {
       });
 
       // cache response
-      await redis.set(cacheKey, JSON.stringify(usage), 'EX', 30).catch(() => {});
+      await redis.set(cacheKey, JSON.stringify(usage), 'EX', 30).catch(() => { });
 
       reply.status(200).send({
         usage,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -80,18 +80,19 @@ export async function buildServer() {
         { name: 'simulations', description: 'Pricing simulation scenarios and runs' },
       ],
       securityDefinitions: {
-        apiKeyAuth: {
+        ApiKeyAuth: {
           type: 'apiKey',
           name: 'x-api-key',
           in: 'header',
           description: 'Provide your API key',
         },
-      },
-      security: [
-        {
-          apiKeyAuth: [],
+        BearerAuth: {
+          type: 'apiKey',
+          name: 'Authorization',
+          in: 'header',
+          description: 'Bearer <apikey>',
         },
-      ],
+      },
     },
   });
 
@@ -126,6 +127,12 @@ export async function buildServer() {
   server.addHook('onResponse', persistAuditLog);
 
   await server.register(async (instance) => {
+    instance.addHook('onRoute', (routeOptions) => {
+      routeOptions.schema = {
+        ...routeOptions.schema,
+        security: [{ ApiKeyAuth: [] }, { BearerAuth: [] }],
+      };
+    });
     instance.addHook('preHandler', verifyTenantId());
     await instance.register(eventsRoutes, { prefix: '/v1/events' });
     await instance.register(usageRoutes, { prefix: '/v1/usage' });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -79,6 +79,19 @@ export async function buildServer() {
         { name: 'alerts', description: 'Alert configuration' },
         { name: 'simulations', description: 'Pricing simulation scenarios and runs' },
       ],
+      securityDefinitions: {
+        apiKeyAuth: {
+          type: 'apiKey',
+          name: 'x-api-key',
+          in: 'header',
+          description: 'Provide your API key',
+        },
+      },
+      security: [
+        {
+          apiKeyAuth: [],
+        },
+      ],
     },
   });
 

--- a/apps/api/src/utils/auth.test.ts
+++ b/apps/api/src/utils/auth.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import { buildServer } from '../server';
+import { apiKeys, db } from '@stripemeter/database';
+import { eq, inArray } from 'drizzle-orm';
 
 describe('Auth & Rate Limit middleware', () => {
   let server: FastifyInstance;
@@ -19,6 +21,105 @@ describe('Auth & Rate Limit middleware', () => {
     const res = await server.inject({ method: 'GET', url: '/v1/events?tenantId=00000000-0000-0000-0000-000000000000' });
     expect(res.statusCode).toBe(401);
   });
+
+  it('should rejects when invalid api key format', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: `/v1/events?tenantId=00000000-0000-0000-0000-000000000000`,
+      headers: {
+        'x-api-key': 'thequickbrownfoxjumpsoverthelazydog',
+      }
+    });
+    expect(res.statusCode).toBe(401);
+  });
 });
 
+describe('Scope & Tenant validation', () => {
+  let server: FastifyInstance;
+  let newApiKeys: string[] = [];
+  const toCreateApiKeys = [
+    { keyName: `test-key-invalid`, scopes: ['resouce:action'] },
+    { keyName: `test-key-valid`, scopes: ['project:read,project:write'] },
+  ];
+  const defaultOrgId = '00000000-0000-0000-0000-000000000000';
+  const invalidOrgId = '00000000-0000-0000-0000-000000000001';
 
+  beforeAll(async () => {
+    process.env.BYPASS_AUTH = '1';
+    server = await buildServer();
+    await server.ready();
+
+    await db.delete(apiKeys).where(inArray(apiKeys.name, toCreateApiKeys.map(e => e.keyName)));
+    for (const { keyName, scopes } of toCreateApiKeys) {
+      const createRes = await server.inject({
+        method: 'POST',
+        url: '/v1/admin/api-keys',
+        payload: { name: keyName, scopes },
+      });
+      expect(createRes.statusCode).toBe(201);
+      const created = JSON.parse(createRes.body);
+      expect(created.apiKey).toMatch(/\./);
+      newApiKeys.push(created.apiKey);
+    }
+    delete process.env.BYPASS_AUTH;
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('should rejects when invalid scope', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: `/v1/events?tenantId=${defaultOrgId}`,
+      headers: {
+        'x-api-key': newApiKeys[0],
+      }
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('should rejects when invalid tenantId', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: `/v1/events?tenantId=${invalidOrgId}`,
+      headers: {
+        'x-api-key': newApiKeys[1],
+      }
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('should succeed on matching tenantId and scope', async () => {
+    const res = await server.inject({
+      method: 'GET',
+      url: `/v1/events?tenantId=${defaultOrgId}`,
+      headers: {
+        'x-api-key': newApiKeys[1],
+      }
+    });
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+describe('Swagger security scheme', () => {
+  let server: FastifyInstance;
+
+  beforeAll(async () => {
+    server = await buildServer();
+    await server.ready();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('should include API key security definition', async () => {
+    const res = await server.inject({ method: 'GET', url: '/docs/json' });
+    expect(res.statusCode).toBe(200);
+    const spec = JSON.parse(res.body);
+
+    expect(spec.securityDefinitions?.ApiKeyAuth).toBeDefined();
+    expect(spec.securityDefinitions?.BearerAuth).toBeDefined();
+  });
+})

--- a/apps/api/src/utils/auth.ts
+++ b/apps/api/src/utils/auth.ts
@@ -3,6 +3,7 @@ import { db } from '@stripemeter/database';
 import { apiKeys } from '@stripemeter/database';
 import { eq, and } from 'drizzle-orm';
 import { createHmac } from 'crypto';
+import { authFailTotal, crossTenantBlockTotal, scopeDenyTotal } from './metrics';
 
 export type TenantContext = {
   organisationId: string;
@@ -22,6 +23,7 @@ export async function verifyApiKey(request: FastifyRequest, reply: FastifyReply)
   const header = request.headers['authorization'] || request.headers['x-api-key'];
   const apiKeyRaw = Array.isArray(header) ? header[0] : header;
   if (!apiKeyRaw) {
+    authFailTotal.inc({ route: request.routerPath, method: request.method });
     return reply.status(401).send({ error: 'Missing API key' });
   }
 
@@ -30,7 +32,11 @@ export async function verifyApiKey(request: FastifyRequest, reply: FastifyReply)
     : apiKeyRaw.toString();
 
   const dotIndex = apiKey.indexOf('.');
-  if (dotIndex < 1) return reply.status(401).send({ error: 'Invalid API key format' });
+  if (dotIndex < 1) {
+    authFailTotal.inc({ route: request.routerPath, method: request.method });
+    return reply.status(401).send({ error: 'Invalid API key format' });
+  }
+
   const prefix = apiKey.substring(0, dotIndex);
   const lastFour = apiKey.substring(apiKey.length - 4);
 
@@ -45,7 +51,10 @@ export async function verifyApiKey(request: FastifyRequest, reply: FastifyReply)
     .digest('base64url');
 
   const match = candidates.find(k => k.secretHash === computed && k.active && !k.revokedAt && (!k.expiresAt || new Date(k.expiresAt) > new Date()));
-  if (!match) return reply.status(401).send({ error: 'Invalid API key' });
+  if (!match) {
+    authFailTotal.inc({ route: request.routerPath, method: request.method });
+    return reply.status(401).send({ error: 'Invalid API key' });
+  }
 
   request.tenant = {
     organisationId: match.organisationId,
@@ -62,8 +71,15 @@ function getKeyDerivationSalt(): string {
 
 export function requireScopes(...scopes: string[]) {
   return async (request: FastifyRequest, reply: FastifyReply) => {
+    const bypass = process.env.BYPASS_AUTH === '1';
+    if (bypass) return;
     const isAllowed = scopes.some(scope => request.tenant?.scopes.includes(scope));
     if (!isAllowed) {
+      scopeDenyTotal.inc({
+        route: request.routerPath,
+        method: request.method,
+        org: request.tenant?.organisationId || 'no-tenant',
+      });
       reply.status(403).send({ error: `Require one of: ${scopes}` });
     }
   }
@@ -71,8 +87,11 @@ export function requireScopes(...scopes: string[]) {
 
 export function verifyTenantId(toVerifyKey: string | null = null) {
   return async (request: FastifyRequest, reply: FastifyReply) => {
+    const bypass = process.env.BYPASS_AUTH === '1';
+    if (bypass) return;
     const organisationId = request.tenant?.organisationId;
     if (!organisationId) {
+      authFailTotal.inc({ route: request.routerPath, method: request.method });
       return reply.status(401).send({ error: 'Unauthenticated' });
     }
 
@@ -88,6 +107,11 @@ export function verifyTenantId(toVerifyKey: string | null = null) {
       if (Array.isArray(toVerify)) {
         const tenantIds: string[] = (toVerify as any[]).map(obj => obj.tenantId);
         if (!tenantIds.every(id => id === organisationId)) {
+          crossTenantBlockTotal.inc({
+            route: request.routerPath,
+            method: request.method,
+            org: organisationId,
+          });
           return reply.status(403).send({ error: `Mismatched tenantId in ${toVerifyKey}` });
         }
       } else if (toVerify && typeof toVerify === 'object') {
@@ -97,6 +121,11 @@ export function verifyTenantId(toVerifyKey: string | null = null) {
 
     const isAllowed = tenantId !== null ? tenantId === organisationId : true;
     if (!isAllowed) {
+      crossTenantBlockTotal.inc({
+        route: request.routerPath,
+        method: request.method,
+        org: organisationId,
+      });
       return reply.status(403).send({ error: `Mismatched tenantId` });
     }
   }

--- a/apps/api/src/utils/auth.ts
+++ b/apps/api/src/utils/auth.ts
@@ -60,4 +60,11 @@ function getKeyDerivationSalt(): string {
   return process.env.API_KEY_SALT || 'dev-api-key-salt';
 }
 
-
+export function requireScopes(...scopes: string[]) {
+  return async (request: FastifyRequest, reply: FastifyReply) => {
+    const isAllowed = scopes.some(scope => request.tenant?.scopes.includes(scope));
+    if (!isAllowed) {
+      reply.status(403).send({ error: `Require one of: ${scopes}` });
+    }
+  }
+}

--- a/apps/api/src/utils/metrics.ts
+++ b/apps/api/src/utils/metrics.ts
@@ -43,6 +43,27 @@ export const ingestLatencyMs = new Histogram({
   buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500],
 });
 
+export const authFailTotal = new Counter({
+  name: 'auth_fail_total',
+  help: 'Total number of authentication failures',
+  registers: [registry],
+  labelNames: ['route', 'method'],
+});
+
+export const crossTenantBlockTotal = new Counter({
+  name: 'cross_tenant_block_total',
+  help: 'Total number of blocked requests due to tenantId mismatch',
+  registers: [registry],
+  labelNames: ['route', 'method', 'org'],
+});
+
+export const scopeDenyTotal = new Counter({
+  name: 'scope_deny_total',
+  help: 'Total number of scope/role authorization denials',
+  registers: [registry],
+  labelNames: ['route', 'method', 'org'],
+});
+
 type MetricsRequest = FastifyRequest & { __metricsStartHr?: bigint };
 
 export function registerHttpMetricsHooks(server: FastifyInstance): void {


### PR DESCRIPTION
**What**
- Add require scope hook
- Add verify tenant id hook
- Add prom counter for `auth_fail_total, cross_tenant_block_total, scope_deny_total`
- Add security definition to swagger docs

**Why**
- To improve auth
- To prohibit cross tenant access

**Test Plan**
- Make requests to any /v1/* apis without api key header, observation: missing api key 401 error
- Make requests to any /v1/* apis (i.e POST /v1/events/ingest requiring `project:read` scope) with an api key insufficient scopes, observation: 403 error
- Make request to get other tenant's resource (i.e GET /v1/events?tenant-id=...), with non-matching api key's organisationId, observation: 403 error

**Related Issues**
- closes #5 
